### PR TITLE
add broccoli as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "mkdirp": "~0.3.5",
-    "broccoli-transform": "~0.0.1"
+    "broccoli-transform": "~0.0.1",
+    "broccoli": "~0.2.0"
   }
 }


### PR DESCRIPTION
currently the index.js script requires broccoli
but it's not in the dependencies causing
consumer's of concat without a dependency on
broccoli themselves to fail
