### PR TITLE
Add header/footer & optional function wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ var concatenated = concat(sourceTree, {
   outputFile: '/assets/app.css',
   separator: '\n', // (optional, defaults to \n)
   wrapInEval: true, // (optional, defaults to false)
+  wrapInFunction: false, // (optional, defaults to true)
   header: '/** Copyright Acme Inc. 2014 **/', // (optional)
   footer: '/** END OF FILE **/' // (optional)
 });
@@ -23,6 +24,7 @@ var concatenated = concat(sourceTree, {
 
 * separator - what to separate the files with, defaults to '\n'
 * wrapInEval - whether to wrap in eval for sourceURL, defaults to false as causes problems with global variables
+* wrapInFunction - whether to wrap output in self-invoking function when wrapping output in eval, defaults to true
 * header - string to prepend to beginning of combined file, separated from beginning of file contents by `separator`
 * footer - string to append to end of combined file, separated from end of file contents by `seperator`
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -82,6 +82,27 @@ describe('broccoli-concat', function(){
     })
   })
 
+  describe('with wrapInFunction set to false', function(){
+    it('does not wrap the output in a self-invoking function', function(){
+      var sourcePath = 'tests/fixtures'
+      var tree = concat(sourcePath, {
+        inputFiles: ['*.js'],
+        outputFile: '/out.js',
+        wrapInEval: true,
+        wrapInFunction: false
+      })
+
+      builder = new broccoli.Builder(tree);
+      return builder.build().then(function(results) {
+        var dir = results.directory;
+        expect(readFile(dir + '/out.js')).to.eql(
+          'eval("var foo = \\\"bar\\\";//@ sourceURL=a-file.js");\n\n'+
+          'eval("var bar = \\\"baz\\\";//@ sourceURL=another-file.js");\n'
+        )
+      })
+    })
+  })
+
   describe('with header', function(){
     it('prepends a header', function(){
       var sourcePath = 'tests/fixtures'


### PR DESCRIPTION
1. Option to specify header/footer
   Use cases:
   - Add copyright notice to file
   - Initialize global object that compiled templates will attach to (ie `this.JST = this.JST || {};`)
2. Option to disable function wrapping when wrapping in eval
   - Addresses comment in #5
