### PR TITLE
Fix: should not stat directories

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,9 @@ Concat.prototype.write = function (readTree, destDir) {
 
     var inputFiles = helpers.multiGlob(self.inputFiles, {cwd: srcDir})
     for (i = 0; i < inputFiles.length; i++) {
-      addFile(inputFiles[i])
+      if (fs.lstatSync(srcDir + '/' + inputFiles[i]).isFile()) { 
+        addFile(inputFiles[i])
+      }
     }
 
     helpers.assertAbsolutePaths([self.outputFile])


### PR DESCRIPTION
It solves the problem when it passes a directory to the `addFile` method and throw an exception.

My case is when using `inputFiles: ['**/*.js']` the folder `ember.js` matches the pattern and originates the error.
