### PR TITLE
Follow symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # master
 
+* Follow symlinks
 * Allow concat to output empty files
 
 # 0.0.7

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ Concat.prototype.write = function (readTree, destDir) {
     try {
       var inputFiles = helpers.multiGlob(self.inputFiles, {cwd: srcDir})
       for (i = 0; i < inputFiles.length; i++) {
-        if (fs.lstatSync(srcDir + '/' + inputFiles[i]).isFile()) { 
+        if (fs.statSync(srcDir + '/' + inputFiles[i]).isFile()) {
           addFile(inputFiles[i])
         }
       }


### PR DESCRIPTION
There is an upcoming change in the Broccoli plugin API (contract), in which we specify that plugins can use symlinks in the trees they emit, and that plugins must follow symlinks in trees they consume. (At the moment, the behavior for symlinks is undefined.)

This change makes broccoli-concat follow symlinks. Without this change, symlinks that point to files would be ignored when they are matched by the `inputFiles` patterns. Now we concatenate them along with actual files.

I believe we can release this immediately, without waiting for the actual API change to occur - the current behavior doesn't seem terribly useful.
