### PR TITLE
Allow concat to output empty files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master
 
+* Allow concat to output empty files
+
 # 0.0.7
 
 * Fix: should not stat directories (thanks @ppcano)

--- a/index.js
+++ b/index.js
@@ -47,10 +47,16 @@ Concat.prototype.write = function (readTree, destDir) {
     // unused cache entries are garbage-collected
     var newCache = {}
 
-    var inputFiles = helpers.multiGlob(self.inputFiles, {cwd: srcDir})
-    for (i = 0; i < inputFiles.length; i++) {
-      if (fs.lstatSync(srcDir + '/' + inputFiles[i]).isFile()) { 
-        addFile(inputFiles[i])
+    try {
+      var inputFiles = helpers.multiGlob(self.inputFiles, {cwd: srcDir})
+      for (i = 0; i < inputFiles.length; i++) {
+        if (fs.lstatSync(srcDir + '/' + inputFiles[i]).isFile()) { 
+          addFile(inputFiles[i])
+        }
+      }
+    } catch(error) {
+      if (!self.allowNone || !error.message.match("did not match any files")) {
+        throw error.message;
       }
     }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -136,4 +136,36 @@ describe('broccoli-concat', function(){
       })
     })
   })
+
+  describe('with no matches', function() {
+    it('outputs empty file with allowNone', function() {
+      var sourcePath = 'tests/fixtures'
+      var tree = concat(sourcePath, {
+        inputFiles: ['*.css'],
+        outputFile: '/out.css',
+        allowNone: true
+      });
+
+      builder = new broccoli.Builder(tree)
+      return builder.build().then(function(results) {
+        var dir = results.directory
+        expect(readFile(dir + '/out.css')).to.eql('');
+      })
+    })
+
+    it('throws error witouth allowNone', function() {
+      var sourcePath = 'tests/fixtures'
+      var tree = concat(sourcePath, {
+        inputFiles: ['*.css'],
+        outputFile: '/out.css'
+      });
+
+      builder = new broccoli.Builder(tree)
+      return builder.build().then(function(results) {
+        expect().fail('allowNone option did not work')
+      }).catch(function(error) {
+        expect(true).to.be.ok()
+      })
+    })
+  })
 });


### PR DESCRIPTION
When there are no matches for the inputFiles

This allows developers to use a null object pattern. It could be the case that trees return no matches but downstream the resulting concated file is still expected.
