### PR TITLE
Link the same file if the content hasn’t changed from the previous build

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "mkdirp": "^0.5.0",
+    "quick-temp": "~0.1.2",
     "broccoli-writer": "^0.1.1",
     "broccoli-kitchen-sink-helpers": "^0.2.4",
     "js-string-escape": "~1.0.0"


### PR DESCRIPTION
Some broccoli libraries, like broccoli-caching-writer, consider the mtimes of files to determine if a tree has changed and whether they need to execute potentially expensive compilation, or whether they can just use their cache.

This commit make broccoli-concat play well with those libraries, by taking an MD5 of the concatenated content after concatenation and comparing it to the
MD5 take in the previous build. If they match, the cached file is used.

By @lukemelia & @raycohen with advice from @rwjblue
