### PR TITLE
Ensure that both cache and dest dirs are cleaned up.

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ Concat.prototype.getCacheDir = function () {
   return quickTemp.makeOrReuse(this, 'tmpCacheDir')
 }
 Concat.prototype.cleanup = function(){
+  Writer.prototype.cleanup.call(this)
   quickTemp.remove(this, 'tmpCacheDir')
 }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -10,6 +10,7 @@ var broccoli = require('broccoli')
 var builder
 
 describe('broccoli-concat', function(){
+  var initialTmpContents;
 
   function readFile(path) {
     return fs.readFileSync(path, {encoding: 'utf8'})
@@ -23,14 +24,23 @@ describe('broccoli-concat', function(){
     process.chdir(path)
   }
 
+  before(function() {
+    if (!fs.existsSync('tmp')) {
+      fs.mkdirSync('tmp');
+    }
+  });
+
   beforeEach(function() {
     chdir(root)
+    initialTmpContents = fs.readdirSync('tmp');
   })
 
   afterEach(function() {
     if (builder) {
       builder.cleanup()
     }
+
+    expect(fs.readdirSync('tmp')).to.eql(initialTmpContents);
   })
 
   describe('with defaults', function(){


### PR DESCRIPTION
broccoli-writer has its own `cleanup` function, to clear the destination directory up. The recent changes (to keep another cache directory) added a `cleanup` function, but that overwrote the one we inherited from `Writer`.

Fixes the build failures that ember-cli is having on the update to `0.0.10`.
