### PR TITLE
Separate utility methods from concat module

### DIFF
--- a/lib/utils/ensure-no-glob.js
+++ b/lib/utils/ensure-no-glob.js
@@ -1,0 +1,14 @@
+var IS_GLOB = /[\{\}\*\[\]]/;
+
+/**
+ * Ensures the provided list of files does not contain any glob expressions.
+ *
+ * @private
+ */
+module.exports = function ensureNoGlob(listName, list) {
+  (list || []).forEach(function(a) {
+    if (IS_GLOB.test(a)) {
+      throw new TypeError(listName + ' cannot contain a glob,  `' + a + '`');
+    }
+  });
+};

--- a/lib/utils/ensure-posix.js
+++ b/lib/utils/ensure-posix.js
@@ -1,0 +1,14 @@
+var path = require('path');
+
+/**
+ * Ensures a given file path uses the posic separator.
+ *
+ * @private
+ */
+module.exports = function ensurePosix(filepath) {
+  if (path.sep !== '/') {
+    return filepath.split(path.sep).join('/');
+  }
+
+  return filepath;
+};

--- a/lib/utils/is-directory.js
+++ b/lib/utils/is-directory.js
@@ -1,0 +1,10 @@
+/**
+ * files returned from listFiles are directories if they end in /
+ * see: https://github.com/joliss/node-walk-sync
+ * "Note that directories come before their contents, and have a trailing slash"
+ *
+ * @private
+ */
+module.exports = function isDirectory(fullPath) {
+  return fullPath.charAt(fullPath.length - 1) === '/';
+};

--- a/lib/utils/make-index.js
+++ b/lib/utils/make-index.js
@@ -1,0 +1,14 @@
+/**
+ * Creates an index of values from two arrays to enable easy lookup.
+ *
+ * @private
+ */
+module.exports = function makeIndex(a, b) {
+  var index = Object.create(null);
+
+  ((a || []).concat(b ||[])).forEach(function(a) {
+    index[a] = true;
+  });
+
+  return index;
+};


### PR DESCRIPTION
Splitting out these methods into some smaller modules makes it a bit less overwhelming to grok what is going on in the main `concat.js` file.

cc @stefanpenner @rwjblue 