### PR TITLE
Remove mkdirp in favor of fs-extra

### DIFF
--- a/concat.js
+++ b/concat.js
@@ -4,7 +4,6 @@ var fs = require('fs-extra');
 var merge = require('lodash.merge');
 var omit = require('lodash.omit');
 var uniq = require('lodash.uniq');
-var mkdirp = require('mkdirp');
 
 module.exports = Concat;
 Concat.prototype = Object.create(CachingWriter.prototype);
@@ -97,7 +96,7 @@ Concat.prototype.build = function() {
   var firstSection = true;
   var outputFile = path.join(this.outputPath, this.outputFile);
 
-  mkdirp.sync(path.dirname(outputFile));
+  fs.mkdirpSync(path.dirname(outputFile));
 
   this.concat = new this.Strategy(merge(this.sourceMapConfig, {
     outputFile: outputFile,

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "fs-extra": "^1.0.0",
     "lodash.merge": "^4.3.0",
     "lodash.omit": "^4.1.0",
-    "lodash.uniq": "^4.2.0",
-    "mkdirp": "^0.5.1"
+    "lodash.uniq": "^4.2.0"
   }
 }


### PR DESCRIPTION
`fs-extra` includes a `mkdirpSync` function and is already being used elsewhere in the same file.

cc @stefanpenner @rwjblue 