### PR TITLE
Do patch-based building for SimpleConcat scenarios

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -13,6 +13,7 @@ This will run benchmarks for initial builds and rebuilds. You can optionally pro
 * `FILE_COUNT` (number, default: 10) - Specifies how many files to concat together in the fixture.
 * `DEPTH` (number, default: 1) - Specifies how many sub-directories of files to place in the fixture. Each directory level will have `FILE_COUNT` files.
 * `LARGE_FILES` (boolean, default: false) - Specifies whether to use fixture files with large memory footprints (>1mb).
+* `SOURCE_MAPS` (boolean, default: true) - Specifies whether to use sourcemap concat.
 
 So, if you want to run many iterations testing the performance of concatenating several large files in a nested structure, you'd run something like:
 

--- a/STRATEGY_API.md
+++ b/STRATEGY_API.md
@@ -8,9 +8,9 @@ By default, `broccoli-concat` ships with [`SimpleConcat`](./lib/strategies/simpl
 
 To provide a custom `Strategy`, you must provide a class that includes the following methods:
 
-- `addFile(file)`: Receives a path to a file to include in the concatenated output.
-- `updateFile(file)`: Receives a path to a file that needs to be updated in the previously concatenated output.
+- `addFile(file, content)`: Receives a path to a file and its contents to include in the concatenated output.
+- `updateFile(file, content)`: Receives a path to a file and its contents that need to be updated in the previously concatenated output.
 - `removeFile(file)`: Receives a path to a file that needs to be removed in the previously concatenated output.
-- `write(outputFile)`: Receives a path to a location for which to write the concatenated result of the above operations.
+- `result()`: Is expected to return the concatenated result of the above operations as a string.
 
 The above methods are intended to represent a "patch-based" approach to concatenating files.

--- a/STRATEGY_API.md
+++ b/STRATEGY_API.md
@@ -1,0 +1,16 @@
+# Concat Strategies
+
+`broccoli-concat` performs file concatenation by using an internal representation called a `Strategy`. You can provide a custom `Strategy` to change how concatenation is done and what features are supported.
+
+By default, `broccoli-concat` ships with [`SimpleConcat`](./lib/strategies/simple.js) as it's default concatenation strategy. It also includes [`fast-sourcemap-concat`](https://github.com/ef4/fast-sourcemap-concat) as a dependency to use when concatenating with sourcemaps.
+
+## Strategy API
+
+To provide a custom `Strategy`, you must provide a class that includes the following methods:
+
+- `addFile(file)`: Receives a path to a file to include in the concatenated output.
+- `updateFile(file)`: Receives a path to a file that needs to be updated in the previously concatenated output.
+- `removeFile(file)`: Receives a path to a file that needs to be removed in the previously concatenated output.
+- `write(outputFile)`: Receives a path to a location for which to write the concatenated result of the above operations.
+
+The above methods are intended to represent a "patch-based" approach to concatenating files.

--- a/bench/fixtures/generator.js
+++ b/bench/fixtures/generator.js
@@ -43,7 +43,9 @@ module.exports = class FixtureGenerator {
    */
   touch() {
     this.fixture['0.js'] += '.';
-    fixturify.writeSync(this.directory, this.fixture);
+    fixturify.writeSync(this.directory, {
+      '0.js': this.fixture['0.js']
+    });
   }
 
   _generateFixture(fileCount, depth, contents) {

--- a/bench/suites/build.js
+++ b/bench/suites/build.js
@@ -21,7 +21,10 @@ module.exports = {
 
   beforeScenario() {
     let node = concat(this.fixture.directory, {
-      outputFile: '/result.js'
+      outputFile: '/result.js',
+      sourceMapConfig: {
+        enabled: process.env.SOURCE_MAPS !== 'false'
+      }
     });
 
     this.builder = new Builder(node);

--- a/bench/suites/rebuild.js
+++ b/bench/suites/rebuild.js
@@ -18,7 +18,10 @@ module.exports = {
     );
 
     let node = concat(this.fixture.directory, {
-      outputFile: '/result.js'
+      outputFile: '/result.js',
+      sourceMapConfig: {
+        enabled: process.env.SOURCE_MAPS !== 'false'
+      }
     });
 
     this.builder = new Builder(node);

--- a/concat.js
+++ b/concat.js
@@ -143,6 +143,17 @@ Concat.prototype._doPatchBasedBuild = function(patch) {
     throw new Error('Concat: Result is empty and allowNone is falsy.');
   }
 
+  if (process.env.CONCAT_STATS) {
+    var fileSizes = this.concat.fileSizes();
+    var outputPath = process.cwd() + '/concat-stats-for/' + this.id + '-' + path.basename(this.outputFile) + '.json';
+
+    fs.mkdirpSync(path.dirname(outputPath));
+    fs.writeFileSync(outputPath, JSON.stringify({
+      outputFile: this.outputFile,
+      sizes: fileSizes
+    }, null, 2));
+  }
+
   fs.outputFileSync(outputFile, content);
 };
 

--- a/index.js
+++ b/index.js
@@ -23,5 +23,5 @@ module.exports = function(inputNode, options) {
     }
   }
 
-  return new Concat(inputNode, options, Strategy || require('./concat-without-source-maps'));
+  return new Concat(inputNode, options, Strategy || require('./lib/strategies/simple'));
 };

--- a/lib/strategies/simple.js
+++ b/lib/strategies/simple.js
@@ -1,6 +1,4 @@
 'use strict';
-var fs = require('fs-extra');
-var path = require('path');
 var findIndex = require('find-index');
 var merge = require('lodash.merge');
 
@@ -10,8 +8,6 @@ function contentMapper(entry) {
 
 function SimpleConcat(attrs) {
   this.separator = attrs.separator || '';
-  this.inputDir = attrs.inputDir;
-  this.allowNone = attrs.allowNone;
 
   this.header = attrs.header;
   this.headerFiles = attrs.headerFiles || [];
@@ -73,9 +69,7 @@ SimpleConcat.prototype = merge(SimpleConcat.prototype, {
     return false;
   },
 
-  addFile: function(file) {
-    var content = fs.readFileSync(path.join(this.inputDir, file), 'UTF-8');
-
+  addFile: function(file, content) {
     if (this._handleHeaderOrFooterFile(file, content)) {
       return;
     }
@@ -93,9 +87,7 @@ SimpleConcat.prototype = merge(SimpleConcat.prototype, {
     }
   },
 
-  updateFile: function(file) {
-    var content = fs.readFileSync(path.join(this.inputDir, file), 'UTF-8');
-
+  updateFile: function(file, content) {
     if (this._handleHeaderOrFooterFile(file, content)) {
       return;
     }
@@ -123,7 +115,7 @@ SimpleConcat.prototype = merge(SimpleConcat.prototype, {
     this._internal.splice(index, 1);
   },
 
-  write: function(outputFile) {
+  result: function(outputFile) {
     // DISCUSS IN REVIEW: Should we store a concatenated string and splice it
     // with updates? Would require keeping pointers to the start and end of
     // files and updating those during operations.
@@ -135,11 +127,7 @@ SimpleConcat.prototype = merge(SimpleConcat.prototype, {
       this.footer
     ).filter(Boolean).join(this.separator);
 
-    if (!content && !this.allowNone) {
-      throw Error('Concatenation result is empty.');
-    }
-
-    fs.outputFileSync(outputFile, content);
+    return content;
   },
 });
 

--- a/lib/strategies/simple.js
+++ b/lib/strategies/simple.js
@@ -1,0 +1,146 @@
+'use strict';
+var fs = require('fs-extra');
+var path = require('path');
+var findIndex = require('find-index');
+var merge = require('lodash.merge');
+
+function contentMapper(entry) {
+  return entry.content;
+}
+
+function SimpleConcat(attrs) {
+  this.separator = attrs.separator || '';
+  this.inputDir = attrs.inputDir;
+  this.allowNone = attrs.allowNone;
+
+  this.header = attrs.header;
+  this.headerFiles = attrs.headerFiles || [];
+  this.footerFiles = attrs.footerFiles || [];
+  this.footer = attrs.footer;
+
+  // Internally, we represent the concatenation as a series of entries. These
+  // entries have a 'file' attribute for lookup/sorting and a 'content' property
+  // which represents the value to be used in the concatenation.
+  this._internal = [];
+
+  // We represent the header/footer files as empty at first so that we don't
+  // have to figure out order when patching
+  this._internalHeaderFiles = this.headerFiles.map(function(file) { return { file: file } });
+  this._internalFooterFiles = this.footerFiles.map(function(file) { return { file: file } });
+}
+
+SimpleConcat.isPatchBased = true;
+
+SimpleConcat.prototype = merge(SimpleConcat.prototype, {
+  /**
+   * Finds the index of the given file in the internal data structure.
+   */
+  _findIndexOf: function(file) {
+    return findIndex(this._internal, function(entry) { return entry.file === file; });
+  },
+
+  /**
+   * Updates the contents of a header file.
+   */
+  _updateHeaderFile: function(fileIndex, content) {
+    this._internalHeaderFiles[fileIndex].content = content;
+  },
+
+  /**
+   * Updates the contents of a footer file.
+   */
+  _updateFooterFile: function(fileIndex, content) {
+    this._internalFooterFiles[fileIndex].content = content;
+  },
+
+  /**
+   * Determines if the given file is a header or footer file, and if so updates
+   * it with the given contents.
+   */
+  _handleHeaderOrFooterFile: function(file, content) {
+    var headerFileIndex = this.headerFiles.indexOf(file);
+    if (headerFileIndex !== -1) {
+      this._updateHeaderFile(headerFileIndex, content);
+      return true;
+    }
+
+    var footerFileIndex = this.footerFiles.indexOf(file);
+    if (footerFileIndex !== -1) {
+      this._updateFooterFile(footerFileIndex, content);
+      return true;
+    }
+
+    return false;
+  },
+
+  addFile: function(file) {
+    var content = fs.readFileSync(path.join(this.inputDir, file), 'UTF-8');
+
+    if (this._handleHeaderOrFooterFile(file, content)) {
+      return;
+    }
+
+    var entry = {
+      file: file,
+      content: content
+    };
+
+    var index = findIndex(this._internal, function(entry) { return entry.file > file; });
+    if (index === -1) {
+      this._internal.push(entry);
+    } else {
+      this._internal.splice(index, 0, entry);
+    }
+  },
+
+  updateFile: function(file) {
+    var content = fs.readFileSync(path.join(this.inputDir, file), 'UTF-8');
+
+    if (this._handleHeaderOrFooterFile(file, content)) {
+      return;
+    }
+
+    var index = this._findIndexOf(file);
+
+    if (index === -1) {
+      throw new Error('Trying to update ' + file + ' but it has not been read before');
+    }
+
+    this._internal[index].content = content;
+  },
+
+  removeFile: function(file) {
+    if (this._handleHeaderOrFooterFile(file, '')) {
+      return;
+    }
+
+    var index = this._findIndexOf(file);
+
+    if (index === -1) {
+      throw new Error('Trying to remove ' + file + ' but it did not previously exist');
+    }
+
+    this._internal.splice(index, 1);
+  },
+
+  write: function(outputFile) {
+    // DISCUSS IN REVIEW: Should we store a concatenated string and splice it
+    // with updates? Would require keeping pointers to the start and end of
+    // files and updating those during operations.
+    var content = [].concat(
+      this.header,
+      this._internalHeaderFiles.map(contentMapper),
+      this._internal.map(contentMapper),
+      this._internalFooterFiles.map(contentMapper),
+      this.footer
+    ).filter(Boolean).join(this.separator);
+
+    if (!content && !this.allowNone) {
+      throw Error('Concatenation result is empty.');
+    }
+
+    fs.outputFileSync(outputFile, content);
+  },
+});
+
+module.exports = SimpleConcat;

--- a/lib/strategies/simple.js
+++ b/lib/strategies/simple.js
@@ -115,10 +115,18 @@ SimpleConcat.prototype = merge(SimpleConcat.prototype, {
     this._internal.splice(index, 1);
   },
 
-  result: function(outputFile) {
-    // DISCUSS IN REVIEW: Should we store a concatenated string and splice it
-    // with updates? Would require keeping pointers to the start and end of
-    // files and updating those during operations.
+  fileSizes: function() {
+    return [].concat(
+      this._internalHeaderFiles,
+      this._internal,
+      this._internalFooterFiles
+    ).reduce(function(sizes, entry) {
+      sizes[entry.file] = entry.content.length;
+      return sizes;
+    }, {});
+  },
+
+  result: function() {
     var content = [].concat(
       this.header,
       this._internalHeaderFiles.map(contentMapper),

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lib/"
   ],
   "scripts": {
-    "test": "mocha",
+    "test": "mocha --recursive",
     "test:debug": "mocha --no-timeouts debug",
     "bench": "node bench/info && bench bench/suites -i 10"
   },
@@ -38,6 +38,7 @@
     "broccoli-stew": "^1.3.3",
     "ensure-posix-path": "^1.0.2",
     "fast-sourcemap-concat": "^1.0.1",
+    "find-index": "^1.1.0",
     "fs-extra": "^1.0.0",
     "fs-tree-diff": "^0.5.6",
     "lodash.merge": "^4.3.0",

--- a/test/strategies/simple-test.js
+++ b/test/strategies/simple-test.js
@@ -1,277 +1,185 @@
 var SimpleConcat = require('../../lib/strategies/simple');
-
-var path = require('path');
-var chai = require('chai');
-var chaiFiles = require('chai-files');
-var quickTemp = require('quick-temp');
-var fixturify = require('fixturify');
-
-chai.use(chaiFiles);
-
-var expect = chai.expect;
-var file = chaiFiles.file;
+var expect = require('chai').expect;
 
 describe('SimpleConcat', function() {
-  var outputFile;
-  var inputDir;
-
-  beforeEach(function() {
-    inputDir = quickTemp.makeOrRemake(this, 'tmpInputDir');
-    outputFile = quickTemp.makeOrRemake(this, 'tmpDestDir') + '/' + 'output.js';
-
-    fixturify.writeSync(inputDir, {
-      a: {
-        'a.js': '//a/a',
-        'b.js': '//a/b'
-      },
-      'a.js': '//a',
-      'b.js': '//b',
-      'c.js': '//c'
-    });
-  });
-
-  afterEach(function() {
-    quickTemp.remove(this, 'tmpInputDir');
-    quickTemp.remove(this, 'tmpDestDir');
-  });
-
   it('is patch based', function() {
     expect(SimpleConcat.isPatchBased).to.be.ok;
   });
 
-  it('can handle empty scenarios with allowNone', function() {
-    var concat = new SimpleConcat({
-      allowNone: true
-    });
-    concat.write(outputFile);
-    expect(file(outputFile)).to.equal('');
-  });
-
-  it('throws on empty scenarios without allowNone', function() {
-    var concat = new SimpleConcat({
-      allowNone: false
-    });
-    expect(function() { concat.write(outputFile) }).to.throw('Concatenation result is empty');
+  it('can handle empty scenarios', function() {
+    var concat = new SimpleConcat({});
+    expect(concat.result()).to.equal('');
   });
 
   it('prepends header to the output', function() {
     var concat = new SimpleConcat({
-      inputDir: inputDir,
       header: 'should be first'
     });
-    concat.addFile('a.js');
-    concat.write(outputFile);
-    expect(file(outputFile)).to.equal('should be first//a');
+    concat.addFile('a.js', '//a');
+    expect(concat.result()).to.equal('should be first//a');
   });
 
   it('appends footer to the output', function() {
     var concat = new SimpleConcat({
-      inputDir: inputDir,
       footer: 'should be last'
     });
-    concat.addFile('a.js');
-    concat.write(outputFile);
-    expect(file(outputFile)).to.equal('//ashould be last');
+    concat.addFile('a.js', '//a');
+    expect(concat.result()).to.equal('//ashould be last');
   });
 
   it('prepends header and appends footer to the output', function() {
     var concat = new SimpleConcat({
-      inputDir: inputDir,
       header: 'should be first',
       footer: 'should be last'
     });
-    concat.addFile('a.js');
-    concat.write(outputFile);
-    expect(file(outputFile)).to.equal('should be first//ashould be last');
+    concat.addFile('a.js', '//a');
+    expect(concat.result()).to.equal('should be first//ashould be last');
   });
 
   describe('addFile', function() {
     it('correctly adds files in alphabetical (stable) order', function() {
-      var concat = new SimpleConcat({
-        inputDir: inputDir,
-      });
+      var concat = new SimpleConcat({});
 
-      concat.addFile('a.js');
-      concat.addFile('a/b.js');
-      concat.addFile('a/a.js');
-      concat.addFile('c.js');
-      concat.addFile('b.js');
+      concat.addFile('a.js', '//a');
+      concat.addFile('a/b.js', '//a/b');
+      concat.addFile('a/a.js', '//a/a');
+      concat.addFile('c.js', '//c');
+      concat.addFile('b.js', '//b');
 
-      concat.write(outputFile);
-      expect(file(outputFile)).to.equal('//a//a/a//a/b//b//c');
+      expect(concat.result()).to.equal('//a//a/a//a/b//b//c');
     });
 
     it('correctly orders headerFiles at the front', function() {
       var concat = new SimpleConcat({
-        inputDir: inputDir,
         headerFiles: ['b.js', 'a/a.js']
       });
 
-      concat.addFile('a.js');
-      concat.addFile('a/b.js');
-      concat.addFile('a/a.js');
-      concat.addFile('c.js');
-      concat.addFile('b.js');
+      concat.addFile('a.js', '//a');
+      concat.addFile('a/b.js', '//a/b');
+      concat.addFile('a/a.js', '//a/a');
+      concat.addFile('c.js', '//c');
+      concat.addFile('b.js', '//b');
 
-      concat.write(outputFile);
-      expect(file(outputFile)).to.equal('//b//a/a//a//a/b//c');
+      expect(concat.result()).to.equal('//b//a/a//a//a/b//c');
     });
 
     it('correctly orders footerFiles at the end', function() {
       var concat = new SimpleConcat({
-        inputDir: inputDir,
         footerFiles: ['b.js', 'a/a.js']
       });
 
-      concat.addFile('a.js');
-      concat.addFile('a/b.js');
-      concat.addFile('a/a.js');
-      concat.addFile('c.js');
-      concat.addFile('b.js');
+      concat.addFile('a.js', '//a');
+      concat.addFile('a/b.js', '//a/b');
+      concat.addFile('a/a.js', '//a/a');
+      concat.addFile('c.js', '//c');
+      concat.addFile('b.js', '//b');
 
-      concat.write(outputFile);
-      expect(file(outputFile)).to.equal('//a//a/b//c//b//a/a');
+      expect(concat.result()).to.equal('//a//a/b//c//b//a/a');
     });
   });
 
   describe('updateFile', function() {
     it('correctly updates an existing file', function() {
-      var concat = new SimpleConcat({
-        inputDir: inputDir
-      });
+      var concat = new SimpleConcat({});
 
-      concat.addFile('a.js');
-      concat.write(outputFile);
-      expect(file(outputFile)).to.equal('//a');
+      concat.addFile('a.js', '//a');
+      expect(concat.result()).to.equal('//a');
 
-      fixturify.writeSync(inputDir, {
-        'a.js': '//a-modified'
-      });
-
-      concat.updateFile('a.js');
-      concat.write(outputFile);
-      expect(file(outputFile)).to.equal('//a-modified');
+      concat.updateFile('a.js', '//a-modified');
+      expect(concat.result()).to.equal('//a-modified');
     });
 
     it('correctly updates a header file', function() {
       var concat = new SimpleConcat({
-        inputDir: inputDir,
         headerFiles: [ 'b.js', 'a.js' ]
       });
 
-      concat.addFile('a.js');
-      concat.addFile('b.js');
-      concat.write(outputFile);
-      expect(file(outputFile)).to.equal('//b//a');
+      concat.addFile('a.js', '//a');
+      concat.addFile('b.js', '//b');
+      expect(concat.result()).to.equal('//b//a');
 
-      fixturify.writeSync(inputDir, {
-        'a.js': '//a-modified'
-      });
-
-      concat.updateFile('a.js');
-      concat.write(outputFile);
-      expect(file(outputFile)).to.equal('//b//a-modified');
+      concat.updateFile('a.js', '//a-modified');
+      expect(concat.result()).to.equal('//b//a-modified');
     });
 
     it('correctly updates a footer file', function() {
       var concat = new SimpleConcat({
-        inputDir: inputDir,
         footerFiles: [ 'a.js', 'b.js' ]
       });
 
-      concat.addFile('a.js');
-      concat.addFile('b.js');
-      concat.write(outputFile);
-      expect(file(outputFile)).to.equal('//a//b');
+      concat.addFile('a.js', '//a');
+      concat.addFile('b.js', '//b');
+      expect(concat.result()).to.equal('//a//b');
 
-      fixturify.writeSync(inputDir, {
-        'a.js': '//a-modified'
-      });
-
-      concat.updateFile('a.js');
-      concat.write(outputFile);
-      expect(file(outputFile)).to.equal('//a-modified//b');
+      concat.updateFile('a.js', '//a-modified');
+      expect(concat.result()).to.equal('//a-modified//b');
     });
 
     it('throws an error when updating a non-existent file', function() {
-      var concat = new SimpleConcat({
-        inputDir: inputDir
-      });
+      var concat = new SimpleConcat({});
 
       expect(function() {
-        concat.updateFile('a.js')
+        concat.updateFile('a.js', '')
       }).to.throw('Trying to update a.js but it has not been read before');
     });
   });
 
   describe('removeFile', function() {
     it('correctly removes an existing file', function() {
-      var concat = new SimpleConcat({
-        inputDir: inputDir,
-      });
+      var concat = new SimpleConcat({});
 
-      concat.addFile('a.js');
-      concat.addFile('a/b.js');
-      concat.addFile('a/a.js');
-      concat.addFile('c.js');
-      concat.addFile('b.js');
+      concat.addFile('a.js', '//a');
+      concat.addFile('a/b.js', '//a/b');
+      concat.addFile('a/a.js', '//a/a');
+      concat.addFile('c.js', '//c');
+      concat.addFile('b.js', '//b');
 
-      concat.write(outputFile);
-      expect(file(outputFile)).to.equal('//a//a/a//a/b//b//c');
+      expect(concat.result()).to.equal('//a//a/a//a/b//b//c');
 
       concat.removeFile('a/b.js');
       concat.removeFile('c.js');
 
-      concat.write(outputFile);
-      expect(file(outputFile)).to.equal('//a//a/a//b');
+      expect(concat.result()).to.equal('//a//a/a//b');
     });
 
     it('correctly removes a header file', function() {
       var concat = new SimpleConcat({
-        inputDir: inputDir,
         headerFiles: ['b.js', 'a.js']
       });
 
-      concat.addFile('a.js');
-      concat.addFile('a/b.js');
-      concat.addFile('a/a.js');
-      concat.addFile('c.js');
-      concat.addFile('b.js');
+      concat.addFile('a.js', '//a');
+      concat.addFile('a/b.js', '//a/b');
+      concat.addFile('a/a.js', '//a/a');
+      concat.addFile('c.js', '//c');
+      concat.addFile('b.js', '//b');
 
-      concat.write(outputFile);
-      expect(file(outputFile)).to.equal('//b//a//a/a//a/b//c');
+      expect(concat.result()).to.equal('//b//a//a/a//a/b//c');
 
       concat.removeFile('b.js');
 
-      concat.write(outputFile);
-      expect(file(outputFile)).to.equal('//a//a/a//a/b//c');
+      expect(concat.result()).to.equal('//a//a/a//a/b//c');
     });
 
     it('correctly removes a footer file', function() {
       var concat = new SimpleConcat({
-        inputDir: inputDir,
+        footerFiles: ['b.js', 'a.js']
       });
 
-      concat.addFile('a.js');
-      concat.addFile('a/b.js');
-      concat.addFile('a/a.js');
-      concat.addFile('c.js');
-      concat.addFile('b.js');
+      concat.addFile('a.js', '//a');
+      concat.addFile('a/b.js', '//a/b');
+      concat.addFile('a/a.js', '//a/a');
+      concat.addFile('c.js', '//c');
+      concat.addFile('b.js', '//b');
 
-      concat.write(outputFile);
-      expect(file(outputFile)).to.equal('//a//a/a//a/b//b//c');
+      expect(concat.result()).to.equal('//a/a//a/b//c//b//a');
 
-      concat.removeFile('a/b.js');
-      concat.removeFile('c.js');
+      concat.removeFile('b.js');
 
-      concat.write(outputFile);
-      expect(file(outputFile)).to.equal('//a//a/a//b');
+      expect(concat.result()).to.equal('//a/a//a/b//c//a');
     });
 
     it('throws an error when removing a non-existent file', function() {
-      var concat = new SimpleConcat({
-        inputDir: inputDir
-      });
+      var concat = new SimpleConcat({});
 
       expect(function() {
         concat.removeFile('a.js')

--- a/test/strategies/simple-test.js
+++ b/test/strategies/simple-test.js
@@ -1,0 +1,281 @@
+var SimpleConcat = require('../../lib/strategies/simple');
+
+var path = require('path');
+var chai = require('chai');
+var chaiFiles = require('chai-files');
+var quickTemp = require('quick-temp');
+var fixturify = require('fixturify');
+
+chai.use(chaiFiles);
+
+var expect = chai.expect;
+var file = chaiFiles.file;
+
+describe('SimpleConcat', function() {
+  var outputFile;
+  var inputDir;
+
+  beforeEach(function() {
+    inputDir = quickTemp.makeOrRemake(this, 'tmpInputDir');
+    outputFile = quickTemp.makeOrRemake(this, 'tmpDestDir') + '/' + 'output.js';
+
+    fixturify.writeSync(inputDir, {
+      a: {
+        'a.js': '//a/a',
+        'b.js': '//a/b'
+      },
+      'a.js': '//a',
+      'b.js': '//b',
+      'c.js': '//c'
+    });
+  });
+
+  afterEach(function() {
+    quickTemp.remove(this, 'tmpInputDir');
+    quickTemp.remove(this, 'tmpDestDir');
+  });
+
+  it('is patch based', function() {
+    expect(SimpleConcat.isPatchBased).to.be.ok;
+  });
+
+  it('can handle empty scenarios with allowNone', function() {
+    var concat = new SimpleConcat({
+      allowNone: true
+    });
+    concat.write(outputFile);
+    expect(file(outputFile)).to.equal('');
+  });
+
+  it('throws on empty scenarios without allowNone', function() {
+    var concat = new SimpleConcat({
+      allowNone: false
+    });
+    expect(function() { concat.write(outputFile) }).to.throw('Concatenation result is empty');
+  });
+
+  it('prepends header to the output', function() {
+    var concat = new SimpleConcat({
+      inputDir: inputDir,
+      header: 'should be first'
+    });
+    concat.addFile('a.js');
+    concat.write(outputFile);
+    expect(file(outputFile)).to.equal('should be first//a');
+  });
+
+  it('appends footer to the output', function() {
+    var concat = new SimpleConcat({
+      inputDir: inputDir,
+      footer: 'should be last'
+    });
+    concat.addFile('a.js');
+    concat.write(outputFile);
+    expect(file(outputFile)).to.equal('//ashould be last');
+  });
+
+  it('prepends header and appends footer to the output', function() {
+    var concat = new SimpleConcat({
+      inputDir: inputDir,
+      header: 'should be first',
+      footer: 'should be last'
+    });
+    concat.addFile('a.js');
+    concat.write(outputFile);
+    expect(file(outputFile)).to.equal('should be first//ashould be last');
+  });
+
+  describe('addFile', function() {
+    it('correctly adds files in alphabetical (stable) order', function() {
+      var concat = new SimpleConcat({
+        inputDir: inputDir,
+      });
+
+      concat.addFile('a.js');
+      concat.addFile('a/b.js');
+      concat.addFile('a/a.js');
+      concat.addFile('c.js');
+      concat.addFile('b.js');
+
+      concat.write(outputFile);
+      expect(file(outputFile)).to.equal('//a//a/a//a/b//b//c');
+    });
+
+    it('correctly orders headerFiles at the front', function() {
+      var concat = new SimpleConcat({
+        inputDir: inputDir,
+        headerFiles: ['b.js', 'a/a.js']
+      });
+
+      concat.addFile('a.js');
+      concat.addFile('a/b.js');
+      concat.addFile('a/a.js');
+      concat.addFile('c.js');
+      concat.addFile('b.js');
+
+      concat.write(outputFile);
+      expect(file(outputFile)).to.equal('//b//a/a//a//a/b//c');
+    });
+
+    it('correctly orders footerFiles at the end', function() {
+      var concat = new SimpleConcat({
+        inputDir: inputDir,
+        footerFiles: ['b.js', 'a/a.js']
+      });
+
+      concat.addFile('a.js');
+      concat.addFile('a/b.js');
+      concat.addFile('a/a.js');
+      concat.addFile('c.js');
+      concat.addFile('b.js');
+
+      concat.write(outputFile);
+      expect(file(outputFile)).to.equal('//a//a/b//c//b//a/a');
+    });
+  });
+
+  describe('updateFile', function() {
+    it('correctly updates an existing file', function() {
+      var concat = new SimpleConcat({
+        inputDir: inputDir
+      });
+
+      concat.addFile('a.js');
+      concat.write(outputFile);
+      expect(file(outputFile)).to.equal('//a');
+
+      fixturify.writeSync(inputDir, {
+        'a.js': '//a-modified'
+      });
+
+      concat.updateFile('a.js');
+      concat.write(outputFile);
+      expect(file(outputFile)).to.equal('//a-modified');
+    });
+
+    it('correctly updates a header file', function() {
+      var concat = new SimpleConcat({
+        inputDir: inputDir,
+        headerFiles: [ 'b.js', 'a.js' ]
+      });
+
+      concat.addFile('a.js');
+      concat.addFile('b.js');
+      concat.write(outputFile);
+      expect(file(outputFile)).to.equal('//b//a');
+
+      fixturify.writeSync(inputDir, {
+        'a.js': '//a-modified'
+      });
+
+      concat.updateFile('a.js');
+      concat.write(outputFile);
+      expect(file(outputFile)).to.equal('//b//a-modified');
+    });
+
+    it('correctly updates a footer file', function() {
+      var concat = new SimpleConcat({
+        inputDir: inputDir,
+        footerFiles: [ 'a.js', 'b.js' ]
+      });
+
+      concat.addFile('a.js');
+      concat.addFile('b.js');
+      concat.write(outputFile);
+      expect(file(outputFile)).to.equal('//a//b');
+
+      fixturify.writeSync(inputDir, {
+        'a.js': '//a-modified'
+      });
+
+      concat.updateFile('a.js');
+      concat.write(outputFile);
+      expect(file(outputFile)).to.equal('//a-modified//b');
+    });
+
+    it('throws an error when updating a non-existent file', function() {
+      var concat = new SimpleConcat({
+        inputDir: inputDir
+      });
+
+      expect(function() {
+        concat.updateFile('a.js')
+      }).to.throw('Trying to update a.js but it has not been read before');
+    });
+  });
+
+  describe('removeFile', function() {
+    it('correctly removes an existing file', function() {
+      var concat = new SimpleConcat({
+        inputDir: inputDir,
+      });
+
+      concat.addFile('a.js');
+      concat.addFile('a/b.js');
+      concat.addFile('a/a.js');
+      concat.addFile('c.js');
+      concat.addFile('b.js');
+
+      concat.write(outputFile);
+      expect(file(outputFile)).to.equal('//a//a/a//a/b//b//c');
+
+      concat.removeFile('a/b.js');
+      concat.removeFile('c.js');
+
+      concat.write(outputFile);
+      expect(file(outputFile)).to.equal('//a//a/a//b');
+    });
+
+    it('correctly removes a header file', function() {
+      var concat = new SimpleConcat({
+        inputDir: inputDir,
+        headerFiles: ['b.js', 'a.js']
+      });
+
+      concat.addFile('a.js');
+      concat.addFile('a/b.js');
+      concat.addFile('a/a.js');
+      concat.addFile('c.js');
+      concat.addFile('b.js');
+
+      concat.write(outputFile);
+      expect(file(outputFile)).to.equal('//b//a//a/a//a/b//c');
+
+      concat.removeFile('b.js');
+
+      concat.write(outputFile);
+      expect(file(outputFile)).to.equal('//a//a/a//a/b//c');
+    });
+
+    it('correctly removes a footer file', function() {
+      var concat = new SimpleConcat({
+        inputDir: inputDir,
+      });
+
+      concat.addFile('a.js');
+      concat.addFile('a/b.js');
+      concat.addFile('a/a.js');
+      concat.addFile('c.js');
+      concat.addFile('b.js');
+
+      concat.write(outputFile);
+      expect(file(outputFile)).to.equal('//a//a/a//a/b//b//c');
+
+      concat.removeFile('a/b.js');
+      concat.removeFile('c.js');
+
+      concat.write(outputFile);
+      expect(file(outputFile)).to.equal('//a//a/a//b');
+    });
+
+    it('throws an error when removing a non-existent file', function() {
+      var concat = new SimpleConcat({
+        inputDir: inputDir
+      });
+
+      expect(function() {
+        concat.removeFile('a.js')
+      }).to.throw('Trying to remove a.js but it did not previously exist');
+    });
+  });
+});

--- a/test/test.js
+++ b/test/test.js
@@ -357,10 +357,11 @@ describe('sourcemap-concat', function() {
   it('does not ignore empty content when allowNone is not explicitly set and sourcemaps are disabled', function() {
     var node = concat(firstFixture, {
       outputFile: '/nothing.css',
-      inputFiles: ['nothing/*.css']
+      inputFiles: ['nothing/*.css'],
+      sourceMapConfig: { enabled: false }
     });
     builder = new broccoli.Builder(node);
-    return expect(builder.build()).to.be.rejected;
+    return expect(builder.build()).to.be.rejectedWith("Concatenation result is empty");
   });
 
   it('is not fooled by directories named *.js', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -361,7 +361,7 @@ describe('sourcemap-concat', function() {
       sourceMapConfig: { enabled: false }
     });
     builder = new broccoli.Builder(node);
-    return expect(builder.build()).to.be.rejectedWith("Concatenation result is empty");
+    return expect(builder.build()).to.be.rejectedWith("Concat: Result is empty and allowNone is falsy");
   });
 
   it('is not fooled by directories named *.js', function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,9 +60,9 @@ balanced-match@^0.4.1:
   version "0.4.2"
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
 
-bench-cli@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/bench-cli/-/bench-cli-0.0.1.tgz#b95e38f9e2a6f6629e893f41715a6571838cc270"
+bench-cli@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/bench-cli/-/bench-cli-0.1.0.tgz#e6f67eea67d10953b9234a83011af5a8816bf15e"
   dependencies:
     commander "^2.9.0"
     walk-sync "^0.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -365,6 +365,10 @@ finalhandler@0.5.0:
     statuses "~1.3.0"
     unpipe "~1.0.0"
 
+find-index@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-index/-/find-index-1.1.0.tgz#53007c79cd30040d6816d79458e8837d5c5705ef"
+
 findup-sync@^0.2.1:
   version "0.2.1"
   resolved "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz#e0a90a450075c49466ee513732057514b81e878c"


### PR DESCRIPTION
**Work-in-progress**

This PR changes the internal build mechanism to be patch-based. This means that rebuilds will function as a set of operations applied to the previously constructed concatenation. This should likely have negligible impact on initial builds and should make most rebuilds faster as we will only have to read from the file system for files that have changed.

This will leverage the patch format from [fs-tree-diff](https://github.com/stefanpenner/fs-tree-diff).

Tasks:
- [x] Fix failing tests
- [x] Add additional tests
- [x] Cleanup code
- [x] Document new approach
- [x] Run benchmarks (from #101)
- [x] Add concat-stats