### PR TITLE
Implement patch-based source-map concat strategy

### DIFF
--- a/STRATEGY_API.md
+++ b/STRATEGY_API.md
@@ -2,7 +2,7 @@
 
 `broccoli-concat` performs file concatenation by using an internal representation called a `Strategy`. You can provide a custom `Strategy` to change how concatenation is done and what features are supported.
 
-By default, `broccoli-concat` ships with [`SimpleConcat`](./lib/strategies/simple.js) as it's default concatenation strategy. It also includes [`fast-sourcemap-concat`](https://github.com/ef4/fast-sourcemap-concat) as a dependency to use when concatenating with sourcemaps.
+By default, `broccoli-concat` ships with [`SimpleConcat`](./lib/strategies/simple.js) and [`SourceMapConcat`](./lib/strategies/source-map.js) as its default concatenation strategies.
 
 ## Strategy API
 
@@ -13,4 +13,6 @@ To provide a custom `Strategy`, you must provide a class that includes the follo
 - `removeFile(file)`: Receives a path to a file that needs to be removed in the previously concatenated output.
 - `result()`: Is expected to return the concatenated result of the above operations as a string. It should also return `undefined` if there was no input to the operation.
 
-The above methods are intended to represent a "patch-based" approach to concatenating files.
+The above methods are intended to represent a "patch-based" approach to concatenating files. Additionally, to distinguish against an older approach to concatenating, your `Strategy` should define an `isPatchBased` flag on the class.
+
+You can also optionally define a `resultSourceMap()` function which returns a string to be used as the contents of a sourcemap file.

--- a/concat.js
+++ b/concat.js
@@ -108,8 +108,13 @@ Concat.prototype.build = function() {
 };
 
 Concat.prototype._doPatchBasedBuild = function(patch) {
+  var outputFile = path.join(this.outputPath, this.outputFile);
+
   if (!this.concat) {
     this.concat = new this.Strategy(merge(this.sourceMapConfig, {
+      allowNone: this.allowNone,
+      inputPath: this.inputPaths[0],
+      outputFile: outputFile,
       separator: this.separator,
       header: this.header,
       headerFiles: this.headerFiles,
@@ -136,7 +141,6 @@ Concat.prototype._doPatchBasedBuild = function(patch) {
     }
   }
 
-  var outputFile = path.join(this.outputPath, this.outputFile);
   var content = this.concat.result();
 
   // If content is undefined, then we the concat had no input files
@@ -160,6 +164,11 @@ Concat.prototype._doPatchBasedBuild = function(patch) {
   }
 
   fs.outputFileSync(outputFile, content);
+
+  if (this.concat.resultSourceMap) {
+    var sourceMapContent = this.concat.resultSourceMap();
+    fs.outputFileSync(this.concat.mapFile, sourceMapContent);
+  }
 };
 
 Concat.prototype._readFile = function(file) {

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = function(inputNode, options) {
     for (var i=0; i < extensions.length; i++) {
       var ext = '.' + extensions[i].replace(/^\./,'');
       if (options.outputFile.slice(-1 * ext.length) === ext) {
-        Strategy = require('fast-sourcemap-concat');
+        Strategy = require('./lib/strategies/source-map');
         break;
       }
     }

--- a/lib/strategies/source-map.js
+++ b/lib/strategies/source-map.js
@@ -1,0 +1,167 @@
+var path = require('path');
+var merge = require('lodash.merge');
+var SourceMapUrl = require('source-map-url');
+
+var SimpleConcat = require('./simple');
+var SourceMapGenerator = require('../utils/source-map-generator');
+var countNewLines = require('../utils/count-new-lines');
+
+function SourceMapConcat(attrs) {
+  SimpleConcat.apply(this, arguments);
+
+  if (!attrs || (!attrs.outputFile && (!attrs.mapURL || !attrs.file))) {
+    throw new Error("Must specify at least outputFile or mapURL and file");
+  }
+
+  if (attrs.mapFile && !attrs.mapURL) {
+    throw new Error("must specify the mapURL when setting a custom mapFile");
+  }
+
+  this.allowNone = attrs.allowNone;
+  this.outputFile = attrs.outputFile;
+  this.mapFile = attrs.mapFile || (this.outputFile && this.outputFile.replace(/\.js$/, '') + '.map');
+  this.mapURL = attrs.mapURL || (this.mapFile && path.basename(this.mapFile));
+  this.mapCommentType = attrs.mapCommentType || 'line';
+
+  this._generator = new SourceMapGenerator({
+    inputPath: attrs.inputPath,
+    sourceRoot: attrs.sourceRoot,
+    file: attrs.file || path.basename(this.outputFile)
+  });
+  this._filesWithSourceMaps = Object.create(null);
+}
+
+SourceMapConcat.isPatchBased = true;
+
+SourceMapConcat.prototype = merge(Object.create(SimpleConcat.prototype), {
+  constructor: SourceMapConcat,
+
+  /**
+   * A simple helper method to easily invoke a method on the superclass.
+   *
+   * @private
+   */
+  _super: function(method, args) {
+    return SimpleConcat.prototype[method].apply(this, args);
+  },
+
+  /**
+   * Adds a file to the internal representation and properly tracks if it has an
+   * external sourcemap.
+   *
+   * @override
+   */
+  addFile: function(file, content) {
+    if (SourceMapUrl.existsIn(content)) {
+      this._filesWithSourceMaps[file] = SourceMapUrl.getFrom(content);
+      content = SourceMapUrl.removeFrom(content);
+    }
+
+    this._super('addFile', [file, content]);
+  },
+
+  /**
+   * Updates a file in the internal representation and properly tracks if it has
+   * an external sourcemap.
+   *
+   * @override
+   */
+  updateFile: function(file, content) {
+    // Update any reference to another sourcemap
+    if (SourceMapUrl.existsIn(content)) {
+      this._filesWithSourceMaps[file] = SourceMapUrl.getFrom(content);
+      content = SourceMapUrl.removeFrom(content);
+    } else if (this._filesWithSourceMaps[file]) {
+      this._filesWithSourceMaps[file] = undefined;
+    }
+
+    this._super('updateFile', [file, content]);
+  },
+
+  /**
+   * Removes a file in the internal representation and any related external
+   * sourcemap.
+   *
+   * @override
+   */
+  removeFile: function(file) {
+    // Update any reference to another sourcemap
+    if (this._filesWithSourceMaps[file]) {
+      this._filesWithSourceMaps[file] = undefined;
+    }
+
+    this._super('removeFile', [file]);
+  },
+
+  /**
+   * Extends the SimpleConcat#result to include a sourceMappingURL comment.
+   *
+   * @override
+   */
+  result: function() {
+    var result = this._super('result');
+
+    if (result === undefined) {
+      // We return undefined when not allowing none, otherwise we use an empty
+      // string so that we can append the sourceMappingURL comment.
+      if (!this.allowNone) {
+        return;
+      } else {
+        result = '';
+      }
+    }
+
+    if (this.mapCommentType === 'line') {
+      result += '//# sourceMappingURL=' + this.mapURL + '\n';
+    } else {
+      result += '/*# sourceMappingURL=' + this.mapURL + ' */\n';
+    }
+
+    return result;
+  },
+
+  /**
+   * Generates the sourcemap corresponding to the result output.
+   */
+  resultSourceMap: function() {
+    var i;
+
+    // Get all the Entry objects for this concatenation.
+    var inputEntries = [].concat(
+      this._internalHeaderFiles,
+      this._internal,
+      this._internalFooterFiles
+    );
+
+    var map = this._generator.fromEntries(inputEntries, this._filesWithSourceMaps);
+
+    var newlineSeparator = this.separator === '\n';
+
+    if (this.header) {
+      var headerLineCount = newlineSeparator ?
+        countNewLines(this.header) + 1 :
+        countNewLines(this.header);
+
+      for (i = 0; i < headerLineCount; i++) {
+        map.mappings.unshift('');
+      }
+    }
+
+    if (this.footer) {
+      var footerLineCount = newlineSeparator ?
+        countNewLines(this.footer) + 2 :
+        countNewLines(this.footer);
+
+      for (i = 0; i < footerLineCount; i++) {
+        map.mappings.push('');
+      }
+    }
+
+    var joiner = newlineSeparator ? ';' : '';
+    map.mappings = map.mappings.join(joiner);
+
+    return JSON.stringify(map);
+  }
+});
+
+module.exports = SourceMapConcat;

--- a/lib/utils/count-new-lines.js
+++ b/lib/utils/count-new-lines.js
@@ -1,0 +1,8 @@
+module.exports = function countNewLines(src) {
+  var newlinePattern = /(\r?\n)/g;
+  var count = 0;
+  while (newlinePattern.exec(src)) {
+    count++;
+  }
+  return count;
+};

--- a/lib/utils/ensure-posix-eol.js
+++ b/lib/utils/ensure-posix-eol.js
@@ -1,0 +1,9 @@
+var EOL = require('os').EOL;
+
+module.exports = function ensurePosixEOL(string) {
+  if (EOL !== '\n') {
+    string = string.split(EOL).join('\n');
+  }
+
+  return string;
+};

--- a/lib/utils/source-map-generator.js
+++ b/lib/utils/source-map-generator.js
@@ -1,0 +1,316 @@
+var fs = require('fs-extra');
+var path = require('path');
+var merge = require('lodash.merge');
+var Coder = require('fast-sourcemap-concat/lib/coder');
+
+var countNewLines = require('./count-new-lines');
+var ensurePosixEOL = require('./ensure-posix-eol');
+
+function SourceMapGenerator(attrs) {
+  this.inputPath = attrs.inputPath;
+
+  this._map = {
+    version: 3,
+    sources: [],
+    sourcesContent: [],
+    names: [],
+    mappings: []
+  };
+
+  if (attrs.sourceRoot) {
+    this._map.sourceRoot = attrs.sourceRoot;
+  }
+
+  this._map.file = attrs.file;
+
+  this.resetState();
+}
+
+SourceMapGenerator.prototype = merge(SourceMapGenerator.prototype, {
+  resetState: function() {
+    this.column = 0;
+    this.linesMapped = 0;
+    this.encoder = new Coder();
+  },
+
+  /**
+   * Given a set of Entry objects, generates the corresponding sourcemap.
+   */
+  fromEntries: function(entries, filesWithSourceMaps) {
+    this.resetState();
+
+    var concat = this;
+
+    return entries.reduce(function(map, entry) {
+      if (filesWithSourceMaps[entry.file]) {
+        var sourceMapPath = filesWithSourceMaps[entry.file];
+        var externalMap = concat._resolveExternalSourceMap(entry.file, sourceMapPath);
+
+        if (externalMap) {
+          return concat._assimilateSourceMap(map, entry, externalMap); // Assimilate source map
+        } else {
+          return concat._addEntryToSourceMap(map, entry);
+        }
+      } else {
+        return concat._addEntryToSourceMap(map, entry);
+      }
+    }, this._createSourceMap());
+  },
+
+  /**
+   * Creates an empty sourcemap.
+   */
+  _createSourceMap: function() {
+    return merge({}, this._map);
+  },
+
+  /**
+   * Adds a given Entry to a source map.
+   */
+  _addEntryToSourceMap: function(map, entry) {
+    if (!entry.content) {
+      return map;
+    }
+
+    map.sources.push(entry.file);
+    map.sourcesContent.push(entry.content);
+    map.mappings.push(this._encodeEntry(entry, map.sources.length - 1));
+
+    return map;
+  },
+
+  /**
+   * Generates an encoded mapping for the given entry.
+   */
+  _encodeEntry: function(entry, sourceIndex) {
+    var lineCount = countNewLines(entry.content);
+    var mapping = this.encoder.encode({
+      generatedColumn: this.column,
+      source: sourceIndex,
+      originalLine: 0,
+      originalColumn: 0
+    });
+
+    if (lineCount === 0) {
+      // no newline in the source. Keep outputting one big line.
+      this.column += entry.content.length;
+    } else {
+      // end the line
+      this.column = 0;
+      this.encoder.resetColumn();
+      mapping += ';';
+      this.encoder.adjustLine(lineCount - 1);
+    }
+
+    // For the remainder of the lines (if any), we're just following
+    // one-to-one.
+    for (var i = 0; i < lineCount-1; i++) {
+      mapping += 'AACA;';
+    }
+
+    this.linesMapped += lineCount;
+    return mapping;
+  },
+
+  /**
+   * Assimilates an external sourcemap into the passed in sourcemap.
+   */
+  _assimilateSourceMap: function(map, entry, externalMap) {
+    var initialLinesMapped = this.linesMapped;
+    var lineCount = countNewLines(entry.content);
+
+    // Do assimilation
+
+    var sourcesOffset = map.sources.length;
+    var namesOffset = map.names.length;
+
+    map.sources = map.sources.concat(this._resolveSources(externalMap.sources));
+    map.sourcesContent = map.sourcesContent.concat(this._resolveSourcesContent(externalMap, entry.file));
+
+    while (map.sourcesContent.length > map.sources.length) {
+      map.sourcesContent.pop();
+    }
+
+    while (map.sourcesContent.length < map.sources.length) {
+      map.sourcesContent.push(null);
+    }
+
+    map.names = map.names.concat(externalMap.names);
+
+    map.mappings.push(this._mergeMappings(externalMap, sourcesOffset, namesOffset));
+
+    while (this.linesMapped - initialLinesMapped < lineCount) {
+      // This cleans up after upstream sourcemaps that are too short
+      // for their sourcecode so they don't break the rest of our
+      // mapping. Coffeescript does this.
+      map.mappings.push('');
+      this.linesMapped++;
+    }
+
+    while (lineCount < this.linesMapped - initialLinesMapped) {
+      // Likewise, this cleans up after upstream sourcemaps that are
+      // too long for their sourcecode.
+      // TODO: How do we handle this?
+      entry.content += "\n";
+      lineCount++;
+    }
+
+    return map;
+  },
+
+  _mergeMappings: function(externalMap, sourcesOffset, namesOffset, cacheHint) {
+    this.decoder = new Coder();
+
+    var mappings = '';
+    var inputMappings = externalMap.mappings;
+
+    var pattern = /^([;,]*)([^;,]*)/;
+    var continuation = /^([;,]*)((?:AACA;)+)/;
+
+    var initialMappedLines = this.linesMapped;
+
+    var lines;
+
+    while (inputMappings.length > 0) {
+      var match = pattern.exec(inputMappings);
+
+      // If the entry was preceded by separators, copy them through.
+      if (match[1]) {
+        mappings += match[1];
+        lines = match[1].replace(/,/g, '').length;
+        if (lines > 0) {
+          this.linesMapped += lines;
+          this.encoder.resetColumn();
+          this.decoder.resetColumn();
+        }
+      }
+
+      // Re-encode the entry.
+      if (match[2]){
+        var value = this.decoder.decode(match[2]);
+        value.generatedColumn += this.column;
+        this.column = 0;
+
+        if (sourcesOffset && value.hasOwnProperty('source')) {
+          value.source += sourcesOffset;
+          this.decoder.prev_source += sourcesOffset;
+          sourcesOffset = 0;
+        }
+
+        if (namesOffset && value.hasOwnProperty('name')) {
+          value.name += namesOffset;
+          this.decoder.prev_name += namesOffset;
+          namesOffset = 0;
+        }
+
+        mappings += this.encoder.encode(value);
+      }
+
+      inputMappings = inputMappings.slice(match[0].length);
+
+      // Once we've applied any offsets, we can try to jump ahead.
+      if (!sourcesOffset && !namesOffset) {
+        if (cacheHint) {
+          // Our cacheHint tells us what our final encoder state will be
+          // after processing this file. And since we've got nothing
+          // left ahead that needs rewriting, we can just copy the
+          // remaining mappings over and jump to the final encoder
+          // state.
+          mappings += inputMappings;
+          inputMappings = '';
+          this.linesMapped = initialMappedLines + cacheHint.lines;
+          this.encoder = cacheHint.encoder;
+        }
+
+        if ((match = continuation.exec(inputMappings))) {
+          // This is a significant optimization, especially when we're
+          // doing simple line-for-line concatenations.
+          lines = match[2].length / 5;
+          this.encoder.adjustLine(lines);
+          this.encoder.resetColumn();
+          this.decoder.adjustLine(lines);
+          this.decoder.resetColumn();
+          this.linesMapped += lines + match[1].replace(/,/g, '').length;
+          mappings += match[0];
+          inputMappings = inputMappings.slice(match[0].length);
+        }
+      }
+    }
+
+    return mappings;
+  },
+
+  _resolveSources: function(sources) {
+    var inputPath = this.inputPath;
+
+    if (!inputPath) {
+      return sources;
+    }
+
+    return sources.map(function(source) {
+      return source.replace(inputPath, '');
+    });
+  },
+
+  _resolveSourcesContent: function(map, file) {
+    if (map.sourcesContent) {
+      // Upstream srcmap already had inline content, so easy.
+      return map.sourcesContent;
+    } else {
+      // Look for original sources relative to our input source filename.
+      return map.sources.map(function(source) {
+        var fullPath;
+
+        if (path.isAbsolute(source)) {
+          fullPath = source;
+        } else {
+          fullPath = path.join(path.dirname(this._resolveFile(file)), source);
+        }
+
+        return ensurePosixEOL(fs.readFileSync(fullPath, 'utf-8'));
+      }.bind(this));
+    }
+  },
+
+  _resolveFile: function(file) {
+    if (this.inputPath && file.slice(0, 1) !== '/') {
+      return path.join(this.inputPath, file);
+    }
+
+    return file;
+  },
+
+  _resolveExternalSourceMap: function(fileWithSourceMap, externalSourceMapURL) {
+    try {
+      var base64Map = /^data:.+?;base64,/.exec(externalSourceMapURL);
+      var srcMap;
+
+      // If the URL was a base64 encoded sourcemap...
+      if (base64Map) {
+        srcMap = new Buffer(externalSourceMapURL.slice(base64Map[0].length), 'base64');
+      }
+
+      // If the URL was an absolute path, resolve from the input directory
+      else if (this.inputPath && externalSourceMapURL.slice(0,1) === '/') {
+        srcMap = fs.readFileSync(
+          path.join(this.inputPath, externalSourceMapURL),
+          'utf8'
+        );
+      }
+
+      // If the URL was a relative path, resolve from the directory of the file
+      else {
+        srcMap = fs.readFileSync(
+          path.join(path.dirname(this._resolveFile(fileWithSourceMap)), externalSourceMapURL),
+          'utf8'
+        );
+      }
+
+      return JSON.parse(srcMap);
+    } catch (err) {
+      console.log('Warning: ignoring input sourcemap for ' + fileWithSourceMap + ' because ' + err.message);
+    }
+  }
+});
+
+module.exports = SourceMapGenerator;

--- a/test/strategies/sourcemap-test.js
+++ b/test/strategies/sourcemap-test.js
@@ -1,0 +1,238 @@
+var SourceMapConcat = require('../../lib/strategies/source-map');
+var expect = require('chai').expect;
+
+describe('SourceMapConcat', function() {
+  it('is patch based', function() {
+    expect(SourceMapConcat.isPatchBased).to.be.ok;
+  });
+
+  it('can handle no input scenarios', function() {
+    var concat = new SourceMapConcat({
+      outputFile: 'output.js',
+    });
+    expect(concat.result()).to.equal(undefined);
+    expect(concat.resultSourceMap()).to.equal('{"version":3,"sources":[],"sourcesContent":[],"names":[],"mappings":"","file":"output.js"}');
+  });
+
+  it('can handle empty input scenarios', function() {
+    var concat = new SourceMapConcat({
+      outputFile: 'output.js',
+    });
+    concat.addFile('foo.js', '');
+    expect(concat.result()).to.equal('//# sourceMappingURL=output.map\n');
+    expect(concat.resultSourceMap()).to.equal('{"version":3,"sources":[],"sourcesContent":[],"names":[],"mappings":"","file":"output.js"}');
+  });
+
+  it('prepends header to the output', function() {
+    var concat = new SourceMapConcat({
+      outputFile: 'output.js',
+      header: 'should be first'
+    });
+    concat.addFile('a.js', '//a');
+    expect(concat.result()).to.equal('should be first//a//# sourceMappingURL=output.map\n');
+    expect(concat.resultSourceMap()).to.equal('{"version":3,"sources":["a.js"],"sourcesContent":["//a"],"names":[],"mappings":"AAAA","file":"output.js"}');
+  });
+
+  it('appends footer to the output', function() {
+    var concat = new SourceMapConcat({
+      outputFile: 'output.js',
+      footer: 'should be last'
+    });
+    concat.addFile('a.js', '//a');
+    expect(concat.result()).to.equal('//ashould be last\n//# sourceMappingURL=output.map\n');
+    expect(concat.resultSourceMap()).to.equal('{"version":3,"sources":["a.js"],"sourcesContent":["//a"],"names":[],"mappings":"AAAA","file":"output.js"}');
+  });
+
+  it('prepends header and appends footer to the output', function() {
+    var concat = new SourceMapConcat({
+      outputFile: 'output.js',
+      header: 'should be first',
+      footer: 'should be last'
+    });
+    concat.addFile('a.js', '//a');
+    expect(concat.result()).to.equal('should be first//ashould be last\n//# sourceMappingURL=output.map\n');
+    expect(concat.resultSourceMap()).to.equal('{"version":3,"sources":["a.js"],"sourcesContent":["//a"],"names":[],"mappings":"AAAA","file":"output.js"}');
+  });
+
+  describe('addFile', function() {
+    it('correctly adds files in alphabetical (stable) order', function() {
+      var concat = new SourceMapConcat({
+        outputFile: 'output.js',
+      });
+
+      concat.addFile('a.js', '//a');
+      concat.addFile('a/b.js', '//a/b');
+      concat.addFile('a/a.js', '//a/a');
+      concat.addFile('c.js', '//c');
+      concat.addFile('b.js', '//b');
+
+      expect(concat.result()).to.equal('//a//a/a//a/b//b//c//# sourceMappingURL=output.map\n');
+      expect(concat.resultSourceMap()).to.equal('{"version":3,"sources":["a.js","a/a.js","a/b.js","b.js","c.js"],"sourcesContent":["//a","//a/a","//a/b","//b","//c"],"names":[],"mappings":"AAAAGCAAKCAAKCAAGCAA","file":"output.js"}');
+    });
+
+    it('correctly orders headerFiles at the front', function() {
+      var concat = new SourceMapConcat({
+        outputFile: 'output.js',
+        headerFiles: ['b.js', 'a/a.js']
+      });
+
+      concat.addFile('a.js', '//a');
+      concat.addFile('a/b.js', '//a/b');
+      concat.addFile('a/a.js', '//a/a');
+      concat.addFile('c.js', '//c');
+      concat.addFile('b.js', '//b');
+
+      expect(concat.result()).to.equal('//b//a/a//a//a/b//c//# sourceMappingURL=output.map\n');
+      expect(concat.resultSourceMap()).to.equal('{"version":3,"sources":["b.js","a/a.js","a.js","a/b.js","c.js"],"sourcesContent":["//b","//a/a","//a","//a/b","//c"],"names":[],"mappings":"AAAAGCAAKCAAGCAAKCAA","file":"output.js"}');
+    });
+
+    it('correctly orders footerFiles at the end', function() {
+      var concat = new SourceMapConcat({
+        outputFile: 'output.js',
+        footerFiles: ['b.js', 'a/a.js']
+      });
+
+      concat.addFile('a.js', '//a');
+      concat.addFile('a/b.js', '//a/b');
+      concat.addFile('a/a.js', '//a/a');
+      concat.addFile('c.js', '//c');
+      concat.addFile('b.js', '//b');
+
+      expect(concat.result()).to.equal('//a//a/b//c//b//a/a//# sourceMappingURL=output.map\n');
+      expect(concat.resultSourceMap()).to.equal('{"version":3,"sources":["a.js","a/b.js","c.js","b.js","a/a.js"],"sourcesContent":["//a","//a/b","//c","//b","//a/a"],"names":[],"mappings":"AAAAGCAAKCAAGCAAGCAA","file":"output.js"}');
+    });
+  });
+
+  describe('updateFile', function() {
+    it('correctly updates an existing file', function() {
+      var concat = new SourceMapConcat({
+        outputFile: 'output.js',
+      });
+
+      concat.addFile('a.js', '//a');
+      expect(concat.result()).to.equal('//a//# sourceMappingURL=output.map\n');
+      expect(concat.resultSourceMap()).to.equal('{"version":3,"sources":["a.js"],"sourcesContent":["//a"],"names":[],"mappings":"AAAA","file":"output.js"}');
+
+      concat.updateFile('a.js', '//a-modified');
+      expect(concat.result()).to.equal('//a-modified//# sourceMappingURL=output.map\n');
+      expect(concat.resultSourceMap()).to.equal('{"version":3,"sources":["a.js"],"sourcesContent":["//a-modified"],"names":[],"mappings":"AAAA","file":"output.js"}');
+    });
+
+    it('correctly updates a header file', function() {
+      var concat = new SourceMapConcat({
+        outputFile: 'output.js',
+        headerFiles: [ 'b.js', 'a.js' ]
+      });
+
+      concat.addFile('a.js', '//a');
+      concat.addFile('b.js', '//b');
+      expect(concat.result()).to.equal('//b//a//# sourceMappingURL=output.map\n');
+      expect(concat.resultSourceMap()).to.equal('{"version":3,"sources":["b.js","a.js"],"sourcesContent":["//b","//a"],"names":[],"mappings":"AAAAGCAA","file":"output.js"}');
+
+      concat.updateFile('a.js', '//a-modified');
+      expect(concat.result()).to.equal('//b//a-modified//# sourceMappingURL=output.map\n');
+      expect(concat.resultSourceMap()).to.equal('{"version":3,"sources":["b.js","a.js"],"sourcesContent":["//b","//a-modified"],"names":[],"mappings":"AAAAGCAA","file":"output.js"}');
+    });
+
+    it('correctly updates a footer file', function() {
+      var concat = new SourceMapConcat({
+        outputFile: 'output.js',
+        footerFiles: [ 'a.js', 'b.js' ]
+      });
+
+      concat.addFile('a.js', '//a');
+      concat.addFile('b.js', '//b');
+      expect(concat.result()).to.equal('//a//b//# sourceMappingURL=output.map\n');
+      expect(concat.resultSourceMap()).to.equal('{"version":3,"sources":["a.js","b.js"],"sourcesContent":["//a","//b"],"names":[],"mappings":"AAAAGCAA","file":"output.js"}');
+
+      concat.updateFile('a.js', '//a-modified');
+      expect(concat.result()).to.equal('//a-modified//b//# sourceMappingURL=output.map\n');
+      expect(concat.resultSourceMap()).to.equal('{"version":3,"sources":["a.js","b.js"],"sourcesContent":["//a-modified","//b"],"names":[],"mappings":"AAAAYCAA","file":"output.js"}');
+    });
+
+    it('throws an error when updating a non-existent file', function() {
+      var concat = new SourceMapConcat({
+        outputFile: 'output.js',
+      });
+
+      expect(function() {
+        concat.updateFile('a.js', '');
+      }).to.throw('Trying to update a.js but it has not been read before');
+    });
+  });
+
+  describe('removeFile', function() {
+    it('correctly removes an existing file', function() {
+      var concat = new SourceMapConcat({
+        outputFile: 'output.js',
+      });
+
+      concat.addFile('a.js', '//a');
+      concat.addFile('a/b.js', '//a/b');
+      concat.addFile('a/a.js', '//a/a');
+      concat.addFile('c.js', '//c');
+      concat.addFile('b.js', '//b');
+
+      expect(concat.result()).to.equal('//a//a/a//a/b//b//c//# sourceMappingURL=output.map\n');
+      expect(concat.resultSourceMap()).to.equal('{"version":3,"sources":["a.js","a/a.js","a/b.js","b.js","c.js"],"sourcesContent":["//a","//a/a","//a/b","//b","//c"],"names":[],"mappings":"AAAAGCAAKCAAKCAAGCAA","file":"output.js"}');
+
+      concat.removeFile('a/b.js');
+      concat.removeFile('c.js');
+
+      expect(concat.result()).to.equal('//a//a/a//b//# sourceMappingURL=output.map\n');
+      expect(concat.resultSourceMap()).to.equal('{"version":3,"sources":["a.js","a/a.js","b.js"],"sourcesContent":["//a","//a/a","//b"],"names":[],"mappings":"AAAAGCAAKCAA","file":"output.js"}');
+    });
+
+    it('correctly removes a header file', function() {
+      var concat = new SourceMapConcat({
+        outputFile: 'output.js',
+        headerFiles: ['b.js', 'a.js']
+      });
+
+      concat.addFile('a.js', '//a');
+      concat.addFile('a/b.js', '//a/b');
+      concat.addFile('a/a.js', '//a/a');
+      concat.addFile('c.js', '//c');
+      concat.addFile('b.js', '//b');
+
+      expect(concat.result()).to.equal('//b//a//a/a//a/b//c//# sourceMappingURL=output.map\n');
+      expect(concat.resultSourceMap()).to.equal('{"version":3,"sources":["b.js","a.js","a/a.js","a/b.js","c.js"],"sourcesContent":["//b","//a","//a/a","//a/b","//c"],"names":[],"mappings":"AAAAGCAAGCAAKCAAKCAA","file":"output.js"}');
+
+      concat.removeFile('b.js');
+
+      expect(concat.result()).to.equal('//a//a/a//a/b//c//# sourceMappingURL=output.map\n');
+      expect(concat.resultSourceMap()).to.equal('{"version":3,"sources":["a.js","a/a.js","a/b.js","c.js"],"sourcesContent":["//a","//a/a","//a/b","//c"],"names":[],"mappings":"AAAAGCAAKCAAKCAA","file":"output.js"}');
+    });
+
+    it('correctly removes a footer file', function() {
+      var concat = new SourceMapConcat({
+        outputFile: 'output.js',
+        footerFiles: ['b.js', 'a.js']
+      });
+
+      concat.addFile('a.js', '//a');
+      concat.addFile('a/b.js', '//a/b');
+      concat.addFile('a/a.js', '//a/a');
+      concat.addFile('c.js', '//c');
+      concat.addFile('b.js', '//b');
+
+      expect(concat.result()).to.equal('//a/a//a/b//c//b//a//# sourceMappingURL=output.map\n');
+      expect(concat.resultSourceMap()).to.equal('{"version":3,"sources":["a/a.js","a/b.js","c.js","b.js","a.js"],"sourcesContent":["//a/a","//a/b","//c","//b","//a"],"names":[],"mappings":"AAAAKCAAKCAAGCAAGCAA","file":"output.js"}');
+
+      concat.removeFile('b.js');
+
+      expect(concat.result()).to.equal('//a/a//a/b//c//a//# sourceMappingURL=output.map\n');
+      expect(concat.resultSourceMap()).to.equal('{"version":3,"sources":["a/a.js","a/b.js","c.js","a.js"],"sourcesContent":["//a/a","//a/b","//c","//a"],"names":[],"mappings":"AAAAKCAAKCAAGCAA","file":"output.js"}');
+    });
+
+    it('throws an error when removing a non-existent file', function() {
+      var concat = new SourceMapConcat({
+        outputFile: 'output.js',
+      });
+
+      expect(function() {
+        concat.removeFile('a.js');
+      }).to.throw('Trying to remove a.js but it did not previously exist');
+    });
+  });
+});


### PR DESCRIPTION
**Ready for review.**

Similar to https://github.com/broccolijs/broccoli-concat/pull/102, but this time with support for source-maps.

TODO:
- [x] Support concatenation of sourcemaps (assimilate them)
- [x] ~~Add caching of sourcemap encoder/decoder~~ (will do in follow up)
- [x] Add additional tests
  - [x] Unit tests for new SourceMapConcat class
  - [x] Header/Footer multiline scenarios in existing tests
  - [x] ~~Additional rebuild tests~~ (not needed, covered by unit tests above)
- [x] Cleanup code
- [x] Add any new documentation
- [x] Run benchmarks