### PR TITLE
Close testing coverage gap between sourcemap and simple concats

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,8 @@
       2,
       "smart"
     ],
+    "no-extra-semi": 2,
+    "semi": 2,
     "no-eval": 2,
     "guard-for-in": 0,
     "wrap-iife": 0,

--- a/concat-without-source-maps.js
+++ b/concat-without-source-maps.js
@@ -41,7 +41,7 @@ Simple.prototype.end = function(cb, thisArg) {
         outputFile: this.outputFile,
         sizes: this._sizes
       }
-    )
+    );
   }
 
   fs.writeFileSync(this.outputFile, this._internal);

--- a/concat.js
+++ b/concat.js
@@ -219,7 +219,7 @@ Concat.prototype._doLegacyBuild = function() {
 
 Concat.prototype.getCurrentFSTree = function() {
   return FSTree.fromEntries(this.listEntries());
-}
+};
 
 Concat.prototype.listEntries = function() {
   // If we have no inputFiles at all, use undefined as the filter to return

--- a/lib/strategies/simple.js
+++ b/lib/strategies/simple.js
@@ -25,8 +25,8 @@ function SimpleConcat(attrs) {
 
   // We represent the header/footer files as empty at first so that we don't
   // have to figure out order when patching
-  this._internalHeaderFiles = this.headerFiles.map(function(file) { return { file: file } });
-  this._internalFooterFiles = this.footerFiles.map(function(file) { return { file: file } });
+  this._internalHeaderFiles = this.headerFiles.map(function(file) { return { file: file }; });
+  this._internalFooterFiles = this.footerFiles.map(function(file) { return { file: file }; });
 }
 
 SimpleConcat.isPatchBased = true;

--- a/lib/strategies/simple.js
+++ b/lib/strategies/simple.js
@@ -147,6 +147,10 @@ SimpleConcat.prototype = merge(SimpleConcat.prototype, {
       this.footer
     ).filter(notUndefined).join(this.separator);
 
+    if (this.footer) {
+      content += '\n';
+    }
+
     return content;
   },
 });

--- a/test/concat-without-maps-test.js
+++ b/test/concat-without-maps-test.js
@@ -92,6 +92,6 @@ describe('concat-without-maps', function() {
           'inner/second.js': 66
         }
       });
-    })
+    });
   });
 });

--- a/test/helpers/expect-file.js
+++ b/test/helpers/expect-file.js
@@ -45,4 +45,4 @@ module.exports = function expectFile(filename) {
       return this;
     }
   };
-}
+};

--- a/test/simple-concat-test.js
+++ b/test/simple-concat-test.js
@@ -309,7 +309,7 @@ describe('simple-concat', function() {
         return builder.build();
       }).then(function(result) {
         expect(read(result.directory + '/rebuild.js')).to.eql('hi');
-        unlink('omg.js')
+        unlink('omg.js');
         return builder.build();
       }).then(function(result) {
         expect(read(result.directory + '/rebuild.js')).to.eql('');
@@ -335,7 +335,7 @@ describe('simple-concat', function() {
         return builder.build();
       }).then(function(result) {
         expect(read(result.directory + '/rebuild.js')).to.eql('a\nb\nz');
-        unlink('a.js')
+        unlink('a.js');
         return builder.build();
       }).then(function(result) {
         expect(read(result.directory + '/rebuild.js')).to.eql('b\nz');
@@ -524,7 +524,7 @@ describe('simple-concat', function() {
           node.id + '-rebuild.js/other/fourth.js',
           node.id + '-rebuild.js/other/third.js',
         ]);
-      })
+      });
     });
   });
 });

--- a/test/simple-concat-test.js
+++ b/test/simple-concat-test.js
@@ -2,6 +2,7 @@ var concat = require('..');
 var fs = require('fs-extra');
 var path = require('path');
 var broccoli = require('broccoli');
+var walkSync = require('walk-sync');
 var expectFile = require('./helpers/expect-file');
 
 var chai = require('chai');
@@ -15,6 +16,7 @@ var expect = chai.expect;
 var file = chaiFiles.file;
 
 var firstFixture = path.join(__dirname, 'fixtures', 'first');
+var secondFixture = path.join(__dirname, 'fixtures', 'second');
 var emptyFixture = path.join(__dirname, 'fixtures', 'empty');
 
 describe('simple-concat', function() {
@@ -40,6 +42,45 @@ describe('simple-concat', function() {
     });
   });
 
+  /**
+   * Tests below here should appear for both simple-concat and sourcemap-concat.
+   */
+
+  it('concatenates all files in one dir', function() {
+    var node = concat(firstFixture, {
+      outputFile: '/all-inner.js',
+      inputFiles: ['inner/*.js'],
+      sourceMapConfig: { enabled: false }
+    });
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function(result) {
+      expectFile('all-inner.js').withoutSrcURL().in(result);
+    });
+  });
+
+  it('concatenates files across dirs', function() {
+    var node = concat(firstFixture, {
+      outputFile: '/all.js',
+      inputFiles: ['**/*.js'],
+      sourceMapConfig: { enabled: false }
+    });
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function(result) {
+      expectFile('all.js').withoutSrcURL().in(result);
+    });
+  });
+
+  it('concatenates all files across dirs when inputFiles is not specified', function() {
+    var node = concat(firstFixture, {
+      outputFile: '/all.js',
+      sourceMapConfig: { enabled: false }
+    });
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function(result) {
+      expectFile('all.js').withoutSrcURL().in(result);
+    });
+  });
+
   it('inserts header', function() {
     var node = concat(firstFixture, {
       header: "/* This is my header. */",
@@ -51,6 +92,62 @@ describe('simple-concat', function() {
     return builder.build().then(function(result) {
       expectFile('all-with-header.js').withoutSrcURL().in(result);
       expectFile('all-with-header.map').notIn(result);
+    });
+  });
+
+  it('inserts header, headeFiles, footer and footerFiles - and overlaps with inputFiles', function() {
+    var node = concat(firstFixture, {
+      header: '/* This is my header.s*/',
+      headerFiles: ['inner/first.js', 'inner/second.js'],
+      inputFiles: ['**/*.js'],
+      footerFiles: ['other/third.js', 'other/fourth.js'],
+      footer: '/* This is my footer. */',
+      outputFile: '/all-the-things.js',
+      sourceMapConfig: { enabled:  false }
+    });
+
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function(result) {
+      expectFile('all-the-things.js').withoutSrcURL().in(result);
+    });
+  });
+
+  it('headerFiles, but with a glob', function() {
+    expect(function() {
+      concat(firstFixture, {
+        headerFiles: ['inner/*.js'],
+        inputFiles: ['**/*.js'],
+        outputFile: '/all-the-things.js',
+        sourceMapConfig: { enabled: false }
+      });
+    }).to.throw('headerFiles cannot contain a glob,  `inner/*.js`');
+  });
+
+  it('footerFiles, but with a glob', function() {
+    expect(function() {
+      concat(firstFixture, {
+        footerFiles: ['inner/*.js'],
+        inputFiles: ['**/*.js'],
+        outputFile: '/all-the-things.js',
+        sourceMapConfig: { enabled: false }
+      });
+    }).to.throw('footerFiles cannot contain a glob,  `inner/*.js`');
+  });
+
+  it('inserts header, headeFiles, footer and footerFiles (reveresed) - and overlaps with inputFiles', function() {
+    var node = concat(firstFixture, {
+      header: '/* This is my header.s*/',
+      headerFiles: ['inner/second.js', 'inner/first.js'],
+      inputFiles: ['**/*.js'],
+      footerFiles: ['other/fourth.js', 'other/third.js'],
+      footer: '/* This is my footer. */',
+      outputFile: '/all-the-things-reversed.js',
+      sourceMapConfig: { enabled: false }
+    });
+
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function(result) {
+      expectFile('all-the-things-reversed.js').withoutSrcURL().in(result);
     });
   });
 
@@ -89,6 +186,34 @@ describe('simple-concat', function() {
 
       var expected = first + '\n' +  second;
       expect(file(result.directory + '/staged.js')).to.equal(expected);
+    });
+  });
+
+  it('prepends headerFiles', function() {
+    var node = concat(firstFixture, {
+      outputFile: '/inner-with-headers.js',
+      inputFiles: ['inner/*.js'],
+      headerFiles: ['other/third.js', 'other/fourth.js'],
+      sourceMapConfig: { enabled: false }
+    });
+
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function(result) {
+      expectFile('inner-with-headers.js').withoutSrcURL().in(result);
+    });
+  });
+
+  it('prepends headerFiles (order reversed)', function() {
+    var node = concat(firstFixture, {
+      outputFile: '/inner-with-headers-reversed.js',
+      inputFiles: ['inner/*.js'],
+      headerFiles: ['other/fourth.js', 'other/third.js'],
+      sourceMapConfig: { enabled: false }
+    });
+
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function(result) {
+      expectFile('inner-with-headers-reversed.js').withoutSrcURL().in(result);
     });
   });
 
@@ -139,5 +264,267 @@ describe('simple-concat', function() {
     });
     builder = new broccoli.Builder(node);
     return expect(builder.build()).to.be.rejectedWith("Concat: nothing matched [nothing/*.css]");
+  });
+
+  it('is not fooled by directories named *.js', function() {
+    var node = concat(secondFixture, {
+      outputFile: '/sneaky.js',
+      inputFiles: ['**/*.js'],
+      sourceMapConfig: { enabled: false }
+    });
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function(result) {
+      expectFile('sneaky.js').withoutSrcURL().in(result);
+    });
+  });
+
+  describe('rebuild', function() {
+    var inputDir;
+    var quickTemp = require('quick-temp');
+    beforeEach(function() {
+      inputDir = quickTemp.makeOrRemake(this, 'rebuild-tests');
+    });
+
+    // write/unlink in inputDir
+    function write(file, content) { fs.writeFileSync(inputDir + '/' + file, content); }
+    function unlink(file)         { fs.unlinkSync(inputDir + '/' + file); }
+
+    // other helper
+    function read(fullPath)       { return fs.readFileSync(fullPath, 'UTF8'); }
+
+    it('add/remove inputFile', function() {
+      var node = concat(inputDir, {
+        outputFile: '/rebuild.js',
+        inputFiles: ['**/*.js'],
+        allowNone: true,
+        sourceMapConfig: { enabled: false }
+      });
+
+      builder = new broccoli.Builder(node);
+      return builder.build().then(function(result) {
+        expect(fs.readFileSync(result.directory + '/rebuild.js', 'UTF8')).to.eql('');
+
+        write('omg.js', 'hi');
+
+        return builder.build();
+      }).then(function(result) {
+        expect(read(result.directory + '/rebuild.js')).to.eql('hi');
+        unlink('omg.js')
+        return builder.build();
+      }).then(function(result) {
+        expect(read(result.directory + '/rebuild.js')).to.eql('');
+        return builder.build();
+      });
+    });
+
+    it('inputFile ordering', function() {
+      var node = concat(inputDir, {
+        outputFile: '/rebuild.js',
+        inputFiles: ['**/*.js'],
+        allowNone: true,
+        sourceMapConfig: { enabled: false }
+      });
+      builder = new broccoli.Builder(node);
+      return builder.build().then(function(result) {
+        expect(read(result.directory + '/rebuild.js')).to.eql('');
+
+        write('z.js', 'z');
+        write('a.js', 'a');
+        write('b.js', 'b');
+
+        return builder.build();
+      }).then(function(result) {
+        expect(read(result.directory + '/rebuild.js')).to.eql('a\nb\nz');
+        unlink('a.js')
+        return builder.build();
+      }).then(function(result) {
+        expect(read(result.directory + '/rebuild.js')).to.eql('b\nz');
+        write('a.js', 'a');
+        return builder.build();
+      }).then(function(result) {
+        expect(read(result.directory + '/rebuild.js')).to.eql('a\nb\nz');
+        return builder.build();
+      });
+    });
+
+    it('headerFiles', function() {
+      var node = concat(inputDir, {
+        outputFile: '/rebuild.js',
+        headerFiles: ['b.js', 'a.js'],
+        sourceMapConfig: { enabled: false }
+      });
+
+      write('z.js', 'z');
+      write('a.js', 'a');
+      write('b.js', 'b');
+
+      builder = new broccoli.Builder(node);
+      return builder.build().then(function(result) {
+        expect(read(result.directory + '/rebuild.js')).to.eql('b\na');
+        write('a.js', 'a-updated');
+        return builder.build();
+      }).then(function(result) {
+        expect(read(result.directory + '/rebuild.js')).to.eql('b\na-updated');
+        write('a.js', 'a');
+        return builder.build();
+      }).then(function(result) {
+        expect(read(result.directory + '/rebuild.js')).to.eql('b\na');
+        write('z.js', 'z-updated');
+        return builder.build();
+      }).then(function(result){
+        expect(read(result.directory + '/rebuild.js')).to.eql('b\na');
+        return builder.build();
+      });
+    });
+
+    it('footerFiles', function() {
+      var node = concat(inputDir, {
+        outputFile: '/rebuild.js',
+        footerFiles: ['b.js', 'a.js'],
+        sourceMapConfig: { enabled: false }
+      });
+
+      write('z.js', 'z');
+      write('a.js', 'a');
+      write('b.js', 'b');
+
+      builder = new broccoli.Builder(node);
+      return builder.build().then(function(result) {
+        expect(read(result.directory + '/rebuild.js')).to.eql('b\na');
+        write('a.js', 'a-updated');
+        return builder.build();
+      }).then(function(result) {
+        expect(read(result.directory + '/rebuild.js')).to.eql('b\na-updated');
+        write('a.js', 'a');
+        return builder.build();
+      }).then(function(result) {
+        expect(read(result.directory + '/rebuild.js')).to.eql('b\na');
+        write('z.js', 'z-updated');
+        return builder.build();
+      }).then(function(result){
+        expect(read(result.directory + '/rebuild.js')).to.eql('b\na');
+        return builder.build();
+      });
+    });
+
+    it('footerFiles + headerFiles', function() {
+      var node = concat(inputDir, {
+        outputFile: '/rebuild.js',
+        headerFiles: ['b.js'],
+        footerFiles: ['a.js'],
+        sourceMapConfig: { enabled: false }
+      });
+
+      write('z.js', 'z');
+      write('a.js', 'a');
+      write('b.js', 'b');
+
+      builder = new broccoli.Builder(node);
+      return builder.build().then(function(result) {
+        expect(read(result.directory + '/rebuild.js')).to.eql('b\na');
+        write('a.js', 'a-updated');
+        return builder.build();
+      }).then(function(result) {
+        expect(read(result.directory + '/rebuild.js')).to.eql('b\na-updated');
+        write('a.js', 'a');
+        return builder.build();
+      }).then(function(result) {
+        expect(read(result.directory + '/rebuild.js')).to.eql('b\na');
+        write('z.js', 'z-updated');
+        return builder.build();
+      }).then(function(result){
+        expect(read(result.directory + '/rebuild.js')).to.eql('b\na');
+        return builder.build();
+      });
+    });
+
+    it('footerFiles + inputFiles (glob) + headerFiles', function() {
+      var node = concat(inputDir, {
+        outputFile: '/rebuild.js',
+        headerFiles: ['b.js'],
+        footerFiles: ['a.js'],
+        inputFiles: [ '**/*.js'],
+        sourceMapConfig: { enabled: false }
+      });
+
+      write('z.js', 'z');
+      write('a.js', 'a');
+      write('b.js', 'b');
+
+      builder = new broccoli.Builder(node);
+      return builder.build().then(function(result) {
+        expect(read(result.directory + '/rebuild.js')).to.eql('b\nz\na');
+        write('a.js', 'a-updated');
+        return builder.build();
+      }).then(function(result) {
+        expect(read(result.directory + '/rebuild.js')).to.eql('b\nz\na-updated');
+        write('a.js', 'a');
+        return builder.build();
+      }).then(function(result) {
+        expect(read(result.directory + '/rebuild.js')).to.eql('b\nz\na');
+        write('z.js', 'z-updated');
+        return builder.build();
+      }).then(function(result){
+        expect(read(result.directory + '/rebuild.js')).to.eql('b\nz-updated\na');
+        unlink('z.js');
+        return builder.build();
+      }).then(function(result){
+        expect(read(result.directory + '/rebuild.js')).to.eql('b\na');
+        write('z.js', 'z');
+        return builder.build();
+      }).then(function(result){
+        expect(read(result.directory + '/rebuild.js')).to.eql('b\nz\na');
+        return builder.build();
+      });
+    });
+  });
+
+  describe('CONCAT_STATS', function() {
+    var node, inputNodesOutput;
+    var dirPath = process.cwd() + '/concat-stats-for';
+
+    beforeEach(function() {
+      fs.removeSync(dirPath);
+      inputNodesOutput = [];
+      process.env.CONCAT_STATS = true;
+
+      node = concat(firstFixture, {
+        outputFile: '/rebuild.js',
+        inputFiles: ['inner/first.js', 'inner/second.js'],
+        sourceMapConfig: { enabled: false }
+      });
+    });
+
+    afterEach(function() {
+      fs.removeSync(dirPath);
+      inputNodesOutput.length = 0;
+      delete process.env.CONCAT_STATS;
+      builder.cleanup();
+    });
+
+    it('emits files', function() {
+      var dir = fs.statSync(dirPath);
+
+      expect(dir.isDirectory()).to.eql(true);
+      expect(walkSync(dirPath)).to.eql([]);
+
+      builder = new broccoli.Builder(node);
+
+      return builder.build().then(function() {
+        var dir = fs.statSync(dirPath);
+
+        expect(dir.isDirectory()).to.eql(true);
+        expect(walkSync(dirPath)).to.eql([
+          node.id + '-rebuild.js.json',
+          node.id + '-rebuild.js/',
+          node.id + '-rebuild.js/inner/',
+          node.id + '-rebuild.js/inner/first.js',
+          node.id + '-rebuild.js/inner/second.js',
+          node.id + '-rebuild.js/other/',
+          node.id + '-rebuild.js/other/fourth.js',
+          node.id + '-rebuild.js/other/third.js',
+        ]);
+      })
+    });
   });
 });

--- a/test/strategies/simple-test.js
+++ b/test/strategies/simple-test.js
@@ -30,7 +30,7 @@ describe('SimpleConcat', function() {
       footer: 'should be last'
     });
     concat.addFile('a.js', '//a');
-    expect(concat.result()).to.equal('//ashould be last');
+    expect(concat.result()).to.equal('//ashould be last\n');
   });
 
   it('prepends header and appends footer to the output', function() {
@@ -39,7 +39,7 @@ describe('SimpleConcat', function() {
       footer: 'should be last'
     });
     concat.addFile('a.js', '//a');
-    expect(concat.result()).to.equal('should be first//ashould be last');
+    expect(concat.result()).to.equal('should be first//ashould be last\n');
   });
 
   describe('addFile', function() {

--- a/test/strategies/simple-test.js
+++ b/test/strategies/simple-test.js
@@ -125,7 +125,7 @@ describe('SimpleConcat', function() {
       var concat = new SimpleConcat({});
 
       expect(function() {
-        concat.updateFile('a.js', '')
+        concat.updateFile('a.js', '');
       }).to.throw('Trying to update a.js but it has not been read before');
     });
   });
@@ -188,7 +188,7 @@ describe('SimpleConcat', function() {
       var concat = new SimpleConcat({});
 
       expect(function() {
-        concat.removeFile('a.js')
+        concat.removeFile('a.js');
       }).to.throw('Trying to remove a.js but it did not previously exist');
     });
   });


### PR DESCRIPTION
This ensures, where applicable, that sourcemap-concat and simple-concat have the same tests. I considered trying to abstract something to make it easier to test both, but any approach is likely to be more complicated and difficult to get right than just duplicating and adjusting where needed (open to re-evaluating that decision though if anyone feels otherwise).