### PR TITLE
[PATCH]Read synchronously for larger files while concatenating

### DIFF
--- a/concat.js
+++ b/concat.js
@@ -55,6 +55,7 @@ module.exports = class Concat extends Plugin {
     this.footer = options.footer;
     this.footerFiles = options.footerFiles;
     this.separator = (options.separator != null) ? options.separator : '\n';
+    this.contentLimit = options.contentLimit;
 
     ensureNoGlob('headerFiles', this.headerFiles);
     ensureNoGlob('footerFiles', this.footerFiles);
@@ -110,7 +111,9 @@ module.exports = class Concat extends Plugin {
         header: this.header,
         headerFiles: this.headerFiles,
         footerFiles: this.footerFiles,
-        footer: this.footer
+        footer: this.footer,
+        contentLimit: this.contentLimit,
+        baseDir: this.inputPaths[0]
       }));
     }
 

--- a/lib/strategies/simple.js
+++ b/lib/strategies/simple.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const findIndex = require('find-index');
+const fs = require('fs');
 
 function contentMapper(entry) {
   return entry.content;
@@ -8,6 +9,31 @@ function contentMapper(entry) {
 
 function notUndefined(content) {
   return content !== undefined;
+}
+
+class Entry {
+  constructor(file, contentLimit, baseDir) {
+    this._content = undefined;
+    this._contentLimit = contentLimit || 10000;
+    this._baseDir = baseDir;
+    this.file = file;
+  }
+  get content() {
+    if (this._content !== undefined) {
+      return this._content;
+    }
+    let content = fs.readFileSync(`${this._baseDir}${this.file}`, 'utf-8');
+    if (content.length < this._contentLimit) {
+      this._content = content;
+    }
+    return content;
+  }
+
+  set content(value) {
+    if (value.length < this._contentLimit) {
+      this._content = value;
+    }
+  }
 }
 
 class SimpleConcat {
@@ -18,6 +44,8 @@ class SimpleConcat {
     this.headerFiles = attrs.headerFiles || [];
     this.footerFiles = attrs.footerFiles || [];
     this.footer = attrs.footer;
+    this.contentLimit = attrs.contentLimit;
+    this.baseDir = attrs.baseDir ? `${attrs.baseDir}/` : '';
 
     // Internally, we represent the concatenation as a series of entries. These
     // entries have a 'file' attribute for lookup/sorting and a 'content' property
@@ -38,7 +66,8 @@ class SimpleConcat {
   }
 
   /**
-   * Updates the contents of a header file. */
+   * Updates the contents of a header file.
+   */
   _updateHeaderFile(fileIndex, content) {
     this._internalHeaderFiles[fileIndex].content = content;
   }
@@ -74,11 +103,8 @@ class SimpleConcat {
     if (this._handleHeaderOrFooterFile(file, content)) {
       return;
     }
-
-    let entry = {
-      file: file,
-      content: content
-    };
+    
+    let entry = new Entry(file, this.contentLimit, this.baseDir);
 
     let index = findIndex(this._internal, entry => entry.file > file);
     if (index === -1) {
@@ -106,7 +132,6 @@ class SimpleConcat {
     if (this._handleHeaderOrFooterFile(file, undefined)) {
       return;
     }
-
     let index = this._findIndexOf(file);
 
     if (index === -1) {

--- a/test/simple-concat-test.js
+++ b/test/simple-concat-test.js
@@ -44,6 +44,18 @@ describe('simple-concat', function() {
     expectFile('no-sourcemap.map').notIn(result);
   }));
 
+  it('concatenates files with content higher than limit', co.wrap(function* () {
+    var node = concat(firstFixture, {
+      outputFile: '/all-inner.js',
+      inputFiles: ['inner/*.js'],
+      contentLimit: 10,
+      sourceMapConfig: { enabled: false }
+    });
+    builder = new broccoli.Builder(node);
+    let result = yield builder.build();
+    expectFile('all-inner.js').withoutSrcURL().in(result);
+  }));
+
   /**
    * Tests below here should appear for both simple-concat and sourcemap-concat.
    */

--- a/test/strategies/simple-test.js
+++ b/test/strategies/simple-test.js
@@ -2,6 +2,34 @@
 
 const SimpleConcat = require('../../lib/strategies/simple');
 const expect = require('chai').expect;
+const fixturify = require('fixturify');
+
+const testDir = 'test/strategies';
+
+function writeFixturifySync(obj) {
+  fixturify.writeSync(testDir, obj);
+}
+
+beforeEach(function() {
+  writeFixturifySync({
+    'a.js': '//a',
+    a: {
+      'a.js': '//a/a',
+      'b.js': '//a/b'
+    },
+    'b.js': '//b',
+    'c.js': '//c'
+  });
+});
+
+afterEach(function() {
+  writeFixturifySync({
+    'a.js': null,
+    'b.js': null,
+    'c.js': null,
+    a: null
+  });
+});
 
 describe('SimpleConcat', function() {
   it('is patch based', function() {
@@ -14,13 +42,21 @@ describe('SimpleConcat', function() {
   });
 
   it('can handle empty input scenarios', function() {
-    let concat = new SimpleConcat({});
-    concat.addFile('foo.js', '');
+    let concat = new SimpleConcat({
+      baseDir: testDir
+    });
+    let fileContent = '';
+    let obj = {
+      'a.js': fileContent
+    };
+    writeFixturifySync(obj);
+    concat.addFile('a.js', fileContent);
     expect(concat.result()).to.equal('');
   });
 
   it('prepends header to the output', function() {
     let concat = new SimpleConcat({
+      baseDir: testDir,
       header: 'should be first'
     });
     concat.addFile('a.js', '//a');
@@ -29,6 +65,7 @@ describe('SimpleConcat', function() {
 
   it('appends footer to the output', function() {
     let concat = new SimpleConcat({
+      baseDir: testDir,
       footer: 'should be last'
     });
     concat.addFile('a.js', '//a');
@@ -37,6 +74,7 @@ describe('SimpleConcat', function() {
 
   it('prepends header and appends footer to the output', function() {
     let concat = new SimpleConcat({
+      baseDir: testDir,
       header: 'should be first',
       footer: 'should be last'
     });
@@ -46,7 +84,9 @@ describe('SimpleConcat', function() {
 
   describe('addFile', function() {
     it('correctly adds files in alphabetical (stable) order', function() {
-      let concat = new SimpleConcat({});
+      let concat = new SimpleConcat({
+        baseDir: testDir
+      });
 
       concat.addFile('a.js', '//a');
       concat.addFile('a/b.js', '//a/b');
@@ -59,6 +99,7 @@ describe('SimpleConcat', function() {
 
     it('correctly orders headerFiles at the front', function() {
       let concat = new SimpleConcat({
+        baseDir: testDir,
         headerFiles: ['b.js', 'a/a.js']
       });
 
@@ -73,6 +114,7 @@ describe('SimpleConcat', function() {
 
     it('correctly orders footerFiles at the end', function() {
       let concat = new SimpleConcat({
+        baseDir: testDir,
         footerFiles: ['b.js', 'a/a.js']
       });
 
@@ -88,7 +130,9 @@ describe('SimpleConcat', function() {
 
   describe('updateFile', function() {
     it('correctly updates an existing file', function() {
-      let concat = new SimpleConcat({});
+      let concat = new SimpleConcat({
+        baseDir: testDir
+      });
 
       concat.addFile('a.js', '//a');
       expect(concat.result()).to.equal('//a');
@@ -99,7 +143,8 @@ describe('SimpleConcat', function() {
 
     it('correctly updates a header file', function() {
       let concat = new SimpleConcat({
-        headerFiles: [ 'b.js', 'a.js' ]
+        baseDir: testDir,
+        headerFiles: ['b.js', 'a.js' ]
       });
 
       concat.addFile('a.js', '//a');
@@ -112,7 +157,8 @@ describe('SimpleConcat', function() {
 
     it('correctly updates a footer file', function() {
       let concat = new SimpleConcat({
-        footerFiles: [ 'a.js', 'b.js' ]
+        baseDir: testDir,
+        footerFiles: ['a.js', 'b.js' ]
       });
 
       concat.addFile('a.js', '//a');
@@ -134,7 +180,9 @@ describe('SimpleConcat', function() {
 
   describe('removeFile', function() {
     it('correctly removes an existing file', function() {
-      let concat = new SimpleConcat({});
+      let concat = new SimpleConcat({
+        baseDir: testDir
+      });
 
       concat.addFile('a.js', '//a');
       concat.addFile('a/b.js', '//a/b');
@@ -152,6 +200,7 @@ describe('SimpleConcat', function() {
 
     it('correctly removes a header file', function() {
       let concat = new SimpleConcat({
+        baseDir: testDir,
         headerFiles: ['b.js', 'a.js']
       });
 
@@ -170,6 +219,7 @@ describe('SimpleConcat', function() {
 
     it('correctly removes a footer file', function() {
       let concat = new SimpleConcat({
+        baseDir: testDir,
         footerFiles: ['b.js', 'a.js']
       });
 


### PR DESCRIPTION
Same changes as in https://github.com/broccolijs/broccoli-concat/pull/128, but uses `this.inputPaths[0]` to get base directory instead of `this.inputNode` as suggested [here](https://github.com/broccolijs/broccoli-concat/pull/128#issuecomment-408136154)