### PR TITLE
Support custom path for concat stats

### DIFF
--- a/concat.js
+++ b/concat.js
@@ -66,15 +66,19 @@ module.exports = class Concat extends Plugin {
   }
 
   static inputNodesForConcatStats(inputNode, id, outputFile) {
-    let dir = process.cwd() + '/concat-stats-for';
+    let dir = Concat.concatStatsPath();
     fs.mkdirpSync(dir);
 
     return [
       require('broccoli-stew').debug(inputNode, {
-        dir: dir,
+        dir,
         name: id + '-' + path.basename(outputFile)
       })
     ];
+  }
+
+  static concatStatsPath() {
+    return process.env.CONCAT_STATS_PATH || `${process.cwd()}/concat-stats-for`;
   }
 
   calculatePatch() {
@@ -146,7 +150,7 @@ module.exports = class Concat extends Plugin {
 
     if (process.env.CONCAT_STATS) {
       let fileSizes = this.concat.fileSizes();
-      let outputPath = process.cwd() + '/concat-stats-for/' + this.id + '-' + path.basename(this.outputFile) + '.json';
+      let outputPath = path.join(Concat.concatStatsPath(), `${this.id}-${path.basename(this.outputFile)}.json`);
 
       fs.mkdirpSync(path.dirname(outputPath));
       fs.writeFileSync(outputPath, JSON.stringify({

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "broccoli-plugin": "^1.3.0",
     "broccoli-stew": "^1.5.0",
     "ensure-posix-path": "^1.0.2",
-    "fast-sourcemap-concat": "^1.3.1",
+    "fast-sourcemap-concat": "^1.4.0",
     "find-index": "^1.1.0",
     "fs-extra": "^4.0.3",
     "fs-tree-diff": "^0.5.7",

--- a/test/simple-concat-test.js
+++ b/test/simple-concat-test.js
@@ -472,49 +472,68 @@ describe('simple-concat', function() {
 
   describe('CONCAT_STATS', function() {
     let node, inputNodesOutput;
-    let dirPath = process.cwd() + '/concat-stats-for';
 
-    beforeEach(function() {
-      fs.removeSync(dirPath);
-      inputNodesOutput = [];
-      process.env.CONCAT_STATS = true;
+    let runEmitTest = (dirPath) => {
+      beforeEach(function() {
+        fs.removeSync(dirPath);
+        inputNodesOutput = [];
+        process.env.CONCAT_STATS = true;
 
-      node = concat(firstFixture, {
-        outputFile: '/rebuild.js',
-        inputFiles: ['inner/first.js', 'inner/second.js'],
-        sourceMapConfig: { enabled: false }
+        node = concat(firstFixture, {
+          outputFile: '/rebuild.js',
+          inputFiles: ['inner/first.js', 'inner/second.js'],
+          sourceMapConfig: { enabled: false }
+        });
       });
+
+      afterEach(function() {
+        fs.removeSync(dirPath);
+        inputNodesOutput.length = 0;
+        delete process.env.CONCAT_STATS;
+        builder.cleanup();
+      });
+
+      it('emits files', co.wrap(function* () {
+        let dir = fs.statSync(dirPath);
+
+        expect(dir.isDirectory()).to.eql(true);
+        expect(walkSync(dirPath)).to.eql([]);
+
+        builder = new broccoli.Builder(node);
+
+        yield builder.build();
+        dir = fs.statSync(dirPath);
+
+        expect(dir.isDirectory()).to.eql(true);
+        expect(walkSync(dirPath)).to.eql([
+          node.id + '-rebuild.js.json',
+          node.id + '-rebuild.js/',
+          node.id + '-rebuild.js/inner/',
+          node.id + '-rebuild.js/inner/first.js',
+          node.id + '-rebuild.js/inner/second.js',
+          node.id + '-rebuild.js/other/',
+          node.id + '-rebuild.js/other/fourth.js',
+          node.id + '-rebuild.js/other/third.js',
+        ]);
+      }));
+    };
+
+    describe('with default path', function() {
+      runEmitTest(process.cwd() + '/concat-stats-for');
     });
 
-    afterEach(function() {
-      fs.removeSync(dirPath);
-      inputNodesOutput.length = 0;
-      delete process.env.CONCAT_STATS;
-      builder.cleanup();
+    describe('with CONCAT_STATS_PATH', function() {
+      let dir = path.join(require('os').tmpdir(), 'concat_temp_dir');
+
+      beforeEach(function() {
+        process.env.CONCAT_STATS_PATH = dir;
+      });
+
+      afterEach(function() {
+        delete process.env.CONCAT_STATS_PATH;
+      });
+
+      runEmitTest(dir);
     });
-
-    it('emits files', co.wrap(function *() {
-      let dir = fs.statSync(dirPath);
-
-      expect(dir.isDirectory()).to.eql(true);
-      expect(walkSync(dirPath)).to.eql([]);
-
-      builder = new broccoli.Builder(node);
-
-      yield builder.build();
-      dir = fs.statSync(dirPath);
-
-      expect(dir.isDirectory()).to.eql(true);
-      expect(walkSync(dirPath)).to.eql([
-        node.id + '-rebuild.js.json',
-        node.id + '-rebuild.js/',
-        node.id + '-rebuild.js/inner/',
-        node.id + '-rebuild.js/inner/first.js',
-        node.id + '-rebuild.js/inner/second.js',
-        node.id + '-rebuild.js/other/',
-        node.id + '-rebuild.js/other/fourth.js',
-        node.id + '-rebuild.js/other/third.js',
-      ]);
-    }));
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -651,9 +651,9 @@ fast-ordered-set@^1.0.0, fast-ordered-set@^1.0.2:
   dependencies:
     blank-object "^1.0.1"
 
-fast-sourcemap-concat@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/fast-sourcemap-concat/-/fast-sourcemap-concat-1.3.1.tgz#c60dfb1080b3986721c5868e0755858d459bee7b"
+fast-sourcemap-concat@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/fast-sourcemap-concat/-/fast-sourcemap-concat-1.4.0.tgz#122c330d4a2afaff16ad143bc9674b87cd76c8ad"
   dependencies:
     chalk "^2.0.0"
     fs-extra "^5.0.0"
@@ -661,7 +661,7 @@ fast-sourcemap-concat@^1.3.1:
     memory-streams "^0.1.3"
     mkdirp "^0.5.0"
     source-map "^0.4.2"
-    source-map-url "^0.4.0"
+    source-map-url "^0.3.0"
     sourcemap-validator "^1.1.0"
 
 figures@^2.0.0:
@@ -1649,9 +1649,9 @@ slice-ansi@1.0.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
 
-source-map-url@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
+source-map-url@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.3.0.tgz#7ecaf13b57bcd09da8a40c5d269db33799d4aaf9"
 
 source-map@^0.4.2, source-map@^0.4.4:
   version "0.4.4"


### PR DESCRIPTION
Check CONCAT_STATS_PATH environment variable to support a custom path for concat stats files.
This is meant to support tighter integration between broccoli-concat and tools (addons) requiring that
stats data, so they can set a custom path (e.g. system temp) without "polluting" the user's current working dir.

This is not ready to merge yet, as `fast-sourcemap-concat` also needs similar changes here: https://github.com/ef4/fast-sourcemap-concat/pull/55, afterwards the dependency here needs to be updated (which should make the failing test pass).