### PR TITLE
Fix stats output for latest broccoli-debug

### DIFF
--- a/lib/stats-output.js
+++ b/lib/stats-output.js
@@ -8,7 +8,7 @@ module.exports = class StatsOutput extends Debug {
     return super(inputNode, {
       label: options.name,
       baseDir: options.dir,
-      force: false
+      force: true
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "bench-cli": "^0.1.0",
     "broccoli": "^0.16.9",
     "broccoli-merge-trees": "^2.0.0",
+    "broccoli-source": "^1.1.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "chai-files": "^1.2.0",
@@ -36,7 +37,7 @@
     "sourcemap-validator": "^1.1.0"
   },
   "dependencies": {
-    "broccoli-debug": "^0.6.4",
+    "broccoli-debug": "^0.6.5",
     "broccoli-kitchen-sink-helpers": "^0.3.1",
     "broccoli-plugin": "^1.3.0",
     "ensure-posix-path": "^1.0.2",

--- a/test/simple-concat-test.js
+++ b/test/simple-concat-test.js
@@ -7,6 +7,7 @@ const path = require('path');
 const broccoli = require('broccoli');
 const walkSync = require('walk-sync');
 const expectFile = require('./helpers/expect-file');
+const UnwatchedDir = require('broccoli-source').UnwatchedDir;
 
 const chai = require('chai');
 const chaiFiles = require('chai-files');
@@ -504,7 +505,7 @@ describe('simple-concat', function() {
         fs.removeSync(dirPath);
         inputNodesOutput = [];
 
-        node = concat(firstFixture, {
+        node = concat(new UnwatchedDir(firstFixture), {
           outputFile: '/rebuild.js',
           inputFiles: ['inner/first.js', 'inner/second.js'],
           sourceMapConfig: { enabled: false }

--- a/yarn.lock
+++ b/yarn.lock
@@ -132,9 +132,9 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-broccoli-debug@^0.6.4:
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/broccoli-debug/-/broccoli-debug-0.6.4.tgz#986eb3d2005e00e3bb91f9d0a10ab137210cd150"
+broccoli-debug@^0.6.5:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/broccoli-debug/-/broccoli-debug-0.6.5.tgz#164a5cdafd8936e525e702bf8f91f39d758e2e78"
   dependencies:
     broccoli-plugin "^1.2.1"
     fs-tree-diff "^0.5.2"
@@ -185,6 +185,10 @@ broccoli-plugin@^1.3.0:
 broccoli-slow-trees@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/broccoli-slow-trees/-/broccoli-slow-trees-1.1.0.tgz#426c5724e008107e4573f73e8a9ca702916b78f7"
+
+broccoli-source@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/broccoli-source/-/broccoli-source-1.1.0.tgz#54f0e82c8b73f46580cbbc4f578f0b32fca8f809"
 
 broccoli@^0.16.9:
   version "0.16.9"


### PR DESCRIPTION
broccoli-debug 0.6.5 (https://github.com/broccolijs/broccoli-debug/pull/15) introduced a change that caused the StatsOutput plugin to be omitted (returning just the unwrapped input node). We now force the debug node creation.

Related to https://github.com/stefanpenner/broccoli-concat-analyser/issues/32#issuecomment-427338147