### PR TITLE
invalidate `_content` on rebuild if necessary

### DIFF
--- a/lib/strategies/simple.js
+++ b/lib/strategies/simple.js
@@ -30,8 +30,13 @@ class Entry {
   }
 
   set content(value) {
+    // if value is less than content limit, set it; otherwise invalidate
+    // previous content so we don't unexpectedly read from it later and
+    // get the old content
     if (value.length < this._contentLimit) {
       this._content = value;
+    } else {
+      this._content = undefined;
     }
   }
 }

--- a/test/simple-concat-test.js
+++ b/test/simple-concat-test.js
@@ -504,6 +504,32 @@ describe('simple-concat', function() {
 
       await builder.build();
     });
+
+    it('properly invalidates if contentLimit is exceeded on rebuild', async function() {
+      let node = concat(inputDir, {
+        outputFile: '/rebuild.js',
+        inputFiles: ['**/*.js'],
+        allowNone: true,
+        contentLimit: 5,
+        sourceMapConfig: { enabled: false }
+      });
+
+      builder = new broccoli.Builder(node);
+
+      await builder.build();
+      expect(read(builder.outputPath + '/rebuild.js')).to.eql('');
+
+      write('z.js', 'z');
+      write('a.js', 'a');
+      await builder.build();
+      expect(read(builder.outputPath + '/rebuild.js')).to.eql('a\nz');
+
+      write('a.js', 'abcdefg');
+      await builder.build();
+      expect(read(builder.outputPath + '/rebuild.js')).to.eql('abcdefg\nz');
+
+      await builder.build();
+    });
   });
 
   describe('CONCAT_STATS', function() {


### PR DESCRIPTION
There's currently a bug in `Entry` where `_content` isn't invalidated properly on rebuilds. This can lead to changes being made by a developer that will ultimately never be bundled on a local development server; the only real mitigation in this case is to re-start your server.

The failing scenario is as follows:

- As part of `Entry` we set `_content` because some file string's length is less than `contentLimit`
- A rebuild is triggered as a result of some changes that exceed `contentLimit`
- Whenever `content` is subsequently accessed, we'll get the previously cached `_content`, not the new updates as you'd expect